### PR TITLE
Add finfiles to build/mosaic subtiles processing

### DIFF
--- a/qsub_buildSubTiles.sh
+++ b/qsub_buildSubTiles.sh
@@ -26,15 +26,22 @@ echo "var1: ${p1}"
 echo "var2: ${p2}"
 echo "var3: ${p3}"
 echo "var4: ${p4}"
-echo "var4: ${p5}"
-echo "var5: ${p6}"
-echo "var6: ${p7}"
-echo "var7: ${p8}"
-echo "var8: ${p9}"
-echo "var9: ${p10}"
+echo "var5: ${p5}"
+echo "var6: ${p6}"
+echo "var7: ${p7}"
+echo "var8: ${p8}"
+echo "var9: ${p9}"
+echo "var10: ${p10}"
+echo "var11: ${p11}"
 echo
 
-echo matlab -nojvm -nodisplay -nosplash -r "addpath('${p1}'); addpath('${p2}'); ${p3}('${p4}','${p5}','${p6}','${p7}','landTile','${p8}','refDemFile','${p9}','make2m',${p10}); exit"
-time matlab -nojvm -nodisplay -nosplash -r "addpath('${p1}'); addpath('${p2}'); ${p3}('${p4}','${p5}','${p6}','${p7}','landTile','${p8}','refDemFile','${p9}','make2m',${p10}); exit"
+echo matlab -nojvm -nodisplay -nosplash -r "try; addpath('${p1}'); addpath('${p2}'); ${p3}('${p4}','${p5}','${p6}','${p7}','landTile','${p8}','refDemFile','${p9}','make2m',${p10}); catch e; disp(getReport(e)); exit(1); end; exit(0);"
+time matlab -nojvm -nodisplay -nosplash -r "try; addpath('${p1}'); addpath('${p2}'); ${p3}('${p4}','${p5}','${p6}','${p7}','landTile','${p8}','refDemFile','${p9}','make2m',${p10}); catch e; disp(getReport(e)); exit(1); end; exit(0);"
+status=$?
 
 echo "Done"
+
+# create finfile if matlab command exited without error
+if (( status == 0 )); then
+    touch "${p11}"
+fi

--- a/qsub_mosaicSubTiles.sh
+++ b/qsub_mosaicSubTiles.sh
@@ -30,22 +30,30 @@ echo "var6: ${p6}"
 echo "var7: ${p7}"
 echo "var8: ${p8}"
 echo "var9: ${p9}"
+echo "var10: ${p10}"
 
 echo
 
 # Check if quad arg is present
-if [ -z "${p9}" ]; then
+if [ "${p9}" == 'null' ]; then
     echo "Quad arg not present. Running full tile"
 
-    echo matlab -nojvm -nodisplay -nosplash -r "addpath('${p1}'); addpath('${p2}'); [x0,x1,y0,y1]=getTileExtents('${p7}','${p8}'); projstr=getTileProjection('${p8}'); disp(x0); ${p3}('${p4}',${p5},'${p6}','projection',projstr,'extent',[x0,x1,y0,y1]); exit"
-    time matlab -nojvm -nodisplay -nosplash -r "addpath('${p1}'); addpath('${p2}'); [x0,x1,y0,y1]=getTileExtents('${p7}','${p8}'); projstr=getTileProjection('${p8}'); disp(x0); ${p3}('${p4}',${p5},'${p6}','projection',projstr,'extent',[x0,x1,y0,y1]); exit"
+    echo matlab -nojvm -nodisplay -nosplash -r "try; addpath('${p1}'); addpath('${p2}'); [x0,x1,y0,y1]=getTileExtents('${p7}','${p8}'); projstr=getTileProjection('${p8}'); disp(x0); ${p3}('${p4}',${p5},'${p6}','projection',projstr,'extent',[x0,x1,y0,y1]); catch e; disp(getReport(e)); exit(1); end; exit(0);"
+    time matlab -nojvm -nodisplay -nosplash -r "try; addpath('${p1}'); addpath('${p2}'); [x0,x1,y0,y1]=getTileExtents('${p7}','${p8}'); projstr=getTileProjection('${p8}'); disp(x0); ${p3}('${p4}',${p5},'${p6}','projection',projstr,'extent',[x0,x1,y0,y1]); catch e; disp(getReport(e)); exit(1); end; exit(0);"
+    status=$?
 
 else
     echo "Running quadrant ${p9}"
 
-    echo matlab -nojvm -nodisplay -nosplash -r "addpath('${p1}'); addpath('${p2}'); [x0,x1,y0,y1]=getTileExtents('${p7}','${p8}','quadrant','${p9}'); projstr=getTileProjection('${p8}'); ${p3}('${p4}',${p5},'${p6}','projection',projstr,'quadrant','${p9}','extent',[x0,x1,y0,y1]); exit"
-    time matlab -nojvm -nodisplay -nosplash -r "addpath('${p1}'); addpath('${p2}'); [x0,x1,y0,y1]=getTileExtents('${p7}','${p8}','quadrant','${p9}'); projstr=getTileProjection('${p8}'); ${p3}('${p4}',${p5},'${p6}','projection',projstr,'quadrant','${p9}','extent',[x0,x1,y0,y1]); exit"
+    echo matlab -nojvm -nodisplay -nosplash -r "try; addpath('${p1}'); addpath('${p2}'); [x0,x1,y0,y1]=getTileExtents('${p7}','${p8}','quadrant','${p9}'); projstr=getTileProjection('${p8}'); ${p3}('${p4}',${p5},'${p6}','projection',projstr,'quadrant','${p9}','extent',[x0,x1,y0,y1]); catch e; disp(getReport(e)); exit(1); end; exit(0);"
+    time matlab -nojvm -nodisplay -nosplash -r "try; addpath('${p1}'); addpath('${p2}'); [x0,x1,y0,y1]=getTileExtents('${p7}','${p8}','quadrant','${p9}'); projstr=getTileProjection('${p8}'); ${p3}('${p4}',${p5},'${p6}','projection',projstr,'quadrant','${p9}','extent',[x0,x1,y0,y1]); catch e; disp(getReport(e)); exit(1); end; exit(0);"
+    status=$?
 
 fi
 
 echo "Done"
+
+# create finfile if matlab command exited without error
+if (( status == 0 )); then
+    touch "${p10}"
+fi


### PR DESCRIPTION
Finfiles are created if the matlab command doesn't exit in error.
By wrapping the matlab command a try-catch block, this also fixes the issue where the `exit` command was never reached to quit the matlab process if it encountered an error.

I made the name of the finfiles share the basename of the 10000-th subtile matlab file for the buildSubTiles process, and the output tile matlab file for the mosaicSubTiles process.  But I'd be fine with changing the names if these finfiles might confuse the tile packaging process.

Also, I saw that `batch_mosaicSubTiles.py` is already checking for a semaphore file with the suffix '_empty.txt'.  But I don't see any files with this suffix being produced across all the tiles I've run so far, and the suffix itself doesn't come up in a search across all files in the 4.0 branch code.  Maybe this is an artifact of 3.0 mosaicking code?