### PR TITLE
Lots of stuff, I know

### DIFF
--- a/batch_batchmergequadtilebuffer.py
+++ b/batch_batchmergequadtilebuffer.py
@@ -79,16 +79,16 @@ def main():
 
     i=0
     if len(groups) > 0:
-        keys = groups.keys()
+        keys = list(groups.keys())
         keys.sort()
 
         for key in keys:
 
-            print "Submitting tile group from {} {}".format(args.dimension,key)
+            print("Submitting tile group from {} {}".format(args.dimension,key))
             quads = groups[key]
 
             if len(quads) < 2:
-                print "Tile group {} has only 1 member: {}. Skipping".format(key, quads)
+                print("Tile group {} has only 1 member: {}. Skipping".format(key, quads))
             else:
                 tile_str = ";".join(quads)
 
@@ -104,7 +104,7 @@ def main():
                         args.lib_path,
                         qsubpath
                     )
-                    print cmd
+                    print(cmd)
                     if not args.dryrun:
                         subprocess.call(cmd, shell=True)
 
@@ -116,7 +116,7 @@ def main():
                         dstdir,
                         tile_str.replace(";","','")
                     )
-                    print "{}, {}".format(i, cmd)
+                    print("{}, {}".format(i, cmd))
                     if not args.dryrun:
                         subprocess.call(cmd, shell=True)
 

--- a/batch_batchmergequadtilebuffer.py
+++ b/batch_batchmergequadtilebuffer.py
@@ -50,16 +50,32 @@ def main():
         else:
             print("Tile name does not match a known pattern: {}".format(t))
             sys.exit(-1)
-            
+
+        num_quads_missing_mat = 0
         for q in quadnames:
             tq = "{}_{}".format(t,q)
             filename = "{}/{}/{}_2m.mat".format(dstdir,t,tq)
             if not os.path.isfile(filename):
-                print "Tile {} 2m mat file does not exist: {}".format(tq,filename)
+                print("Tile {} 2m mat file does not exist: {}".format(tq,filename))
+                num_quads_missing_mat += 1
             else:
                 if not mos in mosaic_groups:
                     mosaic_groups[mos] = []
                 mosaic_groups[mos].append(tq)
+
+        dstfps_old_pattern = [
+            "{0}/{1}/{1}*2m*.tif".format(dstdir,t),
+            "{0}/{1}/{1}*2m*meta.txt".format(dstdir,t)
+        ]
+        dstfps_old = [fp for pat in dstfps_old_pattern for fp in glob.glob(pat)]
+        if dstfps_old:
+            if num_quads_missing_mat == 4:
+                print("ERROR! No quad mat files exist, but other tile results exist matching {}".format(dstfps_old_pattern))
+                continue
+            print("{}Removing existing tile results matching {}".format('(dryrun) ' if args.dryrun else '', dstfps_old_pattern))
+            if not args.dryrun:
+                for dstfp_old in dstfps_old:
+                    os.remove(dstfp_old)
 
     # group tiles by dimension
     groups = {}

--- a/batch_batchmergetilebuffer.py
+++ b/batch_batchmergetilebuffer.py
@@ -44,6 +44,20 @@ def main():
         else:
             existing_tiles.append(t)
 
+        dstfps_old_pattern = [
+            "{0}/{1}/{1}*2m*.tif".format(dstdir,t),
+            "{0}/{1}/{1}*2m*meta.txt".format(dstdir,t)
+        ]
+        dstfps_old = [fp for pat in dstfps_old_pattern for fp in glob.glob(pat)]
+        if dstfps_old:
+            if not os.path.isfile(filename):
+                print("ERROR! Tile mat file does not exist, but other MST results exist matching {}".format(dstfps_old_pattern))
+                continue
+            print("{}Removing old MST results matching {}".format('(dryrun) ' if args.dryrun else '', dstfps_old_pattern))
+            if not args.dryrun:
+                for dstfp_old in dstfps_old:
+                    os.remove(dstfp_old)
+
     #  group tiles by dimension
     groups = {}
     for tile in existing_tiles:

--- a/batch_batchmergetilebuffer.py
+++ b/batch_batchmergetilebuffer.py
@@ -40,7 +40,7 @@ def main():
     for t in tiles:
         filename = "{0}/{1}/{1}_2m_reg_dem.mat".format(dstdir,t)
         if not os.path.isfile(filename):
-            print "Tile {} 2m dem does not exist: {}".format(t,filename)
+            print("Tile {} 2m dem does not exist: {}".format(t,filename))
         else:
             existing_tiles.append(t)
 

--- a/batch_batchmergetilebuffer.py
+++ b/batch_batchmergetilebuffer.py
@@ -62,16 +62,16 @@ def main():
         
     i=0
     if len(groups) > 0:
-        keys = groups.keys()
+        keys = list(groups.keys())
         keys.sort()
         
         for key in keys:
             
-            print "Submitting tile group from {} {}".format(args.dimension,key)
+            print("Submitting tile group from {} {}".format(args.dimension,key))
             tiles = groups[key]
             
             if len(tiles) < 2:
-                print "Tile group {} has only 1 member: {}. Skipping".format(key, tiles)
+                print("Tile group {} has only 1 member: {}. Skipping".format(key, tiles))
             else:
                 tile_str = ";".join(tiles)
                     
@@ -87,7 +87,7 @@ def main():
                         args.lib_path,
                         qsubpath
                     )
-                    print cmd
+                    print(cmd)
                     if not args.dryrun:
                         subprocess.call(cmd, shell=True)
                 
@@ -99,7 +99,7 @@ def main():
                         dstdir,
                         tile_str.replace(";","','")
                     )
-                    print "{}, {}".format(i, cmd)
+                    print("{}, {}".format(i, cmd))
                     if not args.dryrun:
                         subprocess.call(cmd, shell=True)
 

--- a/batch_buildSubTiles.py
+++ b/batch_buildSubTiles.py
@@ -37,10 +37,10 @@ project_tileDefFile_dict = {
 }
 
 project_databaseFile_dict = {
-    'arcticdem': 'ArcticDEMdatabase4_2m_v4_20201218.mat',
-    # 'rema': 'REMAdatabase4_2m_v4_20200806.mat',
-    'rema': 'rema_strips_v13e.shp',
-    'earthdem': 'EarthDEMdatabase4_2m_v4_20210101.mat',
+    'arcticdem': '/mnt/pgc/data/scratch/claire/repos/setsm_postprocessing_pgc/ArcticDEMdatabase4_2m_v4_20201218.mat',
+    # 'rema': '/mnt/pgc/data/scratch/claire/repos/setsm_postprocessing_pgc/REMAdatabase4_2m_v4_20200806.mat',
+    'rema': '/mnt/pgc/data/scratch/claire/repos/setsm_postprocessing_pgc/rema_strips_v13e.shp',
+    'earthdem': '/mnt/pgc/data/scratch/claire/repos/setsm_postprocessing_pgc/EarthDEMdatabase4_2m_v4_20210101.mat',
 }
 project_waterTileDir_dict = {
     'arcticdem': '/mnt/pgc/data/projects/arcticdem/watermasks/global_surface_water/tiled_watermasks/',
@@ -178,10 +178,10 @@ def main():
         if args.ref_dem is not None and not os.path.isfile(args.ref_dem):
             parser.error("--ref-dem does not exist: {}".format(args.ref_dem))
         projection_string = epsg_projstr_dict[args.epsg]
-        tile_def_abs = os.path.join(scriptdir, args.tile_def)
+        tile_def_abs = os.path.abspath(args.tile_def if os.path.isfile(args.tile_def) else os.path.join(scriptdir, args.tile_def))
         if not os.path.isfile(tile_def_abs):
             parser.error("--tile-def file does not exit: {}".format(tile_def_abs))
-    strip_db_abs = os.path.join(scriptdir, args.strip_db)
+    strip_db_abs = os.path.abspath(args.strip_db if os.path.isfile(args.strip_db) else os.path.join(scriptdir, args.strip_db))
     if not os.path.isfile(strip_db_abs):
         parser.error("--strip-db does not exist: {}".format(strip_db_abs))
     if args.water_tile_dir != '' and not os.path.isdir(args.water_tile_dir):

--- a/batch_buildSubTiles.py
+++ b/batch_buildSubTiles.py
@@ -322,7 +322,7 @@ def main():
                 i+=1
                 if args.pbs:
                     job_name = 'bst_{}'.format(tile)
-                    cmd = r"""qsub -N {1} -v cmd="{2}",finfile="{3}" {0}""".format(
+                    cmd = r"""qsub -N {1} -v task_cmd="{2}",finfile="{3}" {0}""".format(
                         qsubpath,
                         job_name,
                         matlab_cmd.replace(',', '|COMMA|'),

--- a/batch_tileMetav4.m
+++ b/batch_tileMetav4.m
@@ -1,0 +1,27 @@
+%batch_tileMeta
+
+addpath('/mnt/pgc/data/scratch/erik/repos/setsm_postprocessing4');
+
+tiledir='/mnt/pgc/data/elev/dem/setsm/EarthDEM/mosaic/v1/2m';
+project='EarthDEM';
+tileVersion='1.0';
+
+tiledlist=dir([tiledir,'/*']);
+for i=1:length(tiledlist);
+    tilefolder=tiledlist(i);
+    tilefolder_path=[tilefolder.folder,'/',tilefolder.name];
+    if isdir(tilefolder_path)
+        tilematflist=dir([tilefolder_path,'/*2m.mat']);
+        for j=1:length(tilematflist)
+            tilematfile=tilematflist(j);
+            tilematfile=[tilematfile.folder,'/',tilematfile.name];
+            tilemetafile=strrep(tilematfile, '2m.mat', '2m_meta.txt');
+            if isfile(tilemetafile)
+                fprintf("removing metafile: %s\n", tilemetafile);
+                delete(tilemetafile);
+            end
+            fprintf("tileMetav4('%s','project','%s','tileVersion','%s')\n", tilematfile, project, tileVersion);
+            tileMetav4(tilematfile,'project',project,'tileVersion',tileVersion);
+        end
+    end
+end

--- a/batch_tiles2tif_v4.py
+++ b/batch_tiles2tif_v4.py
@@ -74,16 +74,39 @@ def main():
                 dstfp = os.path.join(dstdir,tile,'{}_{}m_dem.tif'.format(tq, args.res))
                 metafp = os.path.join(dstdir,tile,'{}_{}m_meta.txt'.format(tq, args.res))
                 matfile = os.path.join(dstdir,tile,'{}_{}m.mat'.format(tq, args.res))
+
+                run_tile = True
+
                 if not os.path.isfile(matfile):
                     print("Tile {} {}m mat file does not exist: {}".format(tq,args.res,matfile))
+                    run_tile = False
 
-                elif os.path.isfile(dstfp) and not args.rerun and not args.meta_only:
-                    print('{} exists, skipping'.format(dstfp))
+                elif not args.meta_only and os.path.isfile(dstfp):
+                    if args.rerun:
+                        dstfps_old_pattern = [
+                            matfile.replace('.mat', '*.tif'),
+                            metafp
+                        ]
+                        dstfps_old = [fp for pat in dstfps_old_pattern for fp in glob.glob(pat)]
+                        if dstfps_old:
+                            print("{}Removing existing tif tile results matching {}".format('(dryrun) ' if args.dryrun else '', dstfps_old_pattern))
+                            if not args.dryrun:
+                                for dstfp_old in dstfps_old:
+                                    os.remove(dstfp_old)
+                    else:
+                        print('{} exists, skipping'.format(dstfp))
+                        run_tile = False
                 
-                elif os.path.isfile(metafp) and not args.rerun and args.meta_only:
-                    print('{} exists, skipping'.format(metafp))
+                elif args.meta_only and os.path.isfile(metafp):
+                    if args.rerun:
+                        print('Removing existing meta file: {}'.format(metafp))
+                        if not args.dryrun:
+                            os.remove(metafp)
+                    else:
+                        print('{} exists, skipping'.format(metafp))
+                        run_tile = False
 
-                else:
+                if run_tile:
                     ## if pbs, submit to scheduler
                     i+=1
                     if args.pbs:

--- a/qsub_mergequadtilebuffer.sh
+++ b/qsub_mergequadtilebuffer.sh
@@ -4,6 +4,7 @@
 #PBS -m n
 #PBS -k oe
 #PBS -j oe
+#PBS -q batch
 
 echo ________________________________________________________
 echo

--- a/qsub_mergequadtilebuffer.sh
+++ b/qsub_mergequadtilebuffer.sh
@@ -5,12 +5,35 @@
 #PBS -k oe
 #PBS -j oe
 
+echo ________________________________________________________
+echo
+echo PBS Job Log
+echo Start time: $(date)
+echo
+echo Job name: $PBS_JOBNAME
+echo Job ID: $PBS_JOBID
+echo Submitted by user: $USER
+echo User effective group ID: $(id -ng)
+echo
+echo Hostname of submission: $PBS_O_HOST
+echo Submitted to cluster: $PBS_SERVER
+echo Submitted to queue: $PBS_QUEUE
+echo Requested nodes per job: $PBS_NUM_NODES
+echo Requested cores per node: $PBS_NUM_PPN
+echo Requested cores per job: $PBS_NP
+echo Node list file: $PBS_NODEFILE
+echo Nodes assigned to job: $(cat $PBS_NODEFILE)
+echo Running node index: $PBS_O_NODENUM
+echo
+echo Running on hostname: $HOSTNAME
+echo Parent PID: $PPID
+echo Process PID: $$
+echo
+echo Working directory: $PBS_O_WORKDIR
+echo ________________________________________________________
+echo
+
 cd $PBS_O_WORKDIR
-echo $PBS_O_WORKDIR
-echo $PBS_JOBID
-echo $PBS_O_HOST
-echo $PBS_NODEFILE
-echo $a1
 
 module load gdal/2.1.1
 module load matlab/2019a

--- a/qsub_mergetilebuffer.sh
+++ b/qsub_mergetilebuffer.sh
@@ -4,6 +4,7 @@
 #PBS -m n
 #PBS -k oe
 #PBS -j oe
+#PBS -q batch
 
 echo ________________________________________________________
 echo

--- a/qsub_mergetilebuffer.sh
+++ b/qsub_mergetilebuffer.sh
@@ -5,12 +5,35 @@
 #PBS -k oe
 #PBS -j oe
 
+echo ________________________________________________________
+echo
+echo PBS Job Log
+echo Start time: $(date)
+echo
+echo Job name: $PBS_JOBNAME
+echo Job ID: $PBS_JOBID
+echo Submitted by user: $USER
+echo User effective group ID: $(id -ng)
+echo
+echo Hostname of submission: $PBS_O_HOST
+echo Submitted to cluster: $PBS_SERVER
+echo Submitted to queue: $PBS_QUEUE
+echo Requested nodes per job: $PBS_NUM_NODES
+echo Requested cores per node: $PBS_NUM_PPN
+echo Requested cores per job: $PBS_NP
+echo Node list file: $PBS_NODEFILE
+echo Nodes assigned to job: $(cat $PBS_NODEFILE)
+echo Running node index: $PBS_O_NODENUM
+echo
+echo Running on hostname: $HOSTNAME
+echo Parent PID: $PPID
+echo Process PID: $$
+echo
+echo Working directory: $PBS_O_WORKDIR
+echo ________________________________________________________
+echo
+
 cd $PBS_O_WORKDIR
-echo $PBS_O_WORKDIR
-echo $PBS_JOBID
-echo $PBS_O_HOST
-echo $PBS_NODEFILE
-echo $a1
 
 module load gdal/2.1.3
 module load matlab/2019a

--- a/qsub_tiles2tif_v4.sh
+++ b/qsub_tiles2tif_v4.sh
@@ -4,6 +4,7 @@
 #PBS -m n
 #PBS -k oe
 #PBS -j oe
+#PBS -q batch
 
 echo ________________________________________________________
 echo

--- a/qsub_tiles2tif_v4.sh
+++ b/qsub_tiles2tif_v4.sh
@@ -5,12 +5,35 @@
 #PBS -k oe
 #PBS -j oe
 
+echo ________________________________________________________
+echo
+echo PBS Job Log
+echo Start time: $(date)
+echo
+echo Job name: $PBS_JOBNAME
+echo Job ID: $PBS_JOBID
+echo Submitted by user: $USER
+echo User effective group ID: $(id -ng)
+echo
+echo Hostname of submission: $PBS_O_HOST
+echo Submitted to cluster: $PBS_SERVER
+echo Submitted to queue: $PBS_QUEUE
+echo Requested nodes per job: $PBS_NUM_NODES
+echo Requested cores per node: $PBS_NUM_PPN
+echo Requested cores per job: $PBS_NP
+echo Node list file: $PBS_NODEFILE
+echo Nodes assigned to job: $(cat $PBS_NODEFILE)
+echo Running node index: $PBS_O_NODENUM
+echo
+echo Running on hostname: $HOSTNAME
+echo Parent PID: $PPID
+echo Process PID: $$
+echo
+echo Working directory: $PBS_O_WORKDIR
+echo ________________________________________________________
+echo
+
 cd $PBS_O_WORKDIR
-echo $PBS_O_WORKDIR
-echo $PBS_JOBID
-echo $PBS_O_HOST
-echo $PBS_NODEFILE
-echo $a1
 
 module load gdal/2.1.3
 module load matlab/2019a


### PR DESCRIPTION
But there aren't many radical changes here. The most important changes I already discussed with you:
- Existing .tif/meta.txt mosaic tile files for tiles submitted to `batch_batchmergequadtilebuffer.py` and `batch_tiles2tif_v4.py` will be automatically removed before job submission, so [the `find` command steps in the post-processing doc](https://docs.google.com/document/d/1f5DT3Wklay0U_he1znx9oKgmhH7S4W_fP2O-Xi3Z3xQ/edit#heading=h.qadtssw2uq6n) should no longer be necessary. I've already added notes mentioning this new auto-cleanup functionality to the doc, so once you've pulled these changes we can remove the `find` manual deletion step from the doc!
- At the end of BST and MST jobs (still in the jobscript), it will check its own job logfile with `grep -i 'error'` and if it finds any matches, it will not write a finfile.
- Henceforth, the BST and MST python scripts will look for finfiles to determine whether or not tiles need to be rerun! You will need to pass an optional argument to bypass this requirement. **Be careful, or you could remove a whole week's worth of MST results if you're running old tiles that never had finfiles built!** Use `--dryrun` and take a close look before running.