### PR TITLE
buildSubTiles.m fix qc variable names

### DIFF
--- a/buildSubTiles.m
+++ b/buildSubTiles.m
@@ -789,8 +789,8 @@ for j=1:length(nn)
     mttmp = mt(:,:,nn(j));
     BW = false(size(ztmp));
     for k=1:length(qc_x{nn(j)})
-        BW = BW | roipoly(x,y,ztmp,qc.x{nn(j)}{k},...
-            qc.y{nn(j)}{k});
+        BW = BW | roipoly(x,y,ztmp,qc_x{nn(j)}{k},...
+            qc_y{nn(j)}{k});
     end
     ztmp(BW) = NaN;
     z(:,:,nn(j)) = ztmp;


### PR DESCRIPTION
@khsa1 I ran into this error when using the 4.0-tuning branch for REMA 2m production at PGC, and I think the fix here was pretty clear.