### PR TITLE
Allow parallelization of mosaicSubtiles

### DIFF
--- a/batch_buildSubTiles.py
+++ b/batch_buildSubTiles.py
@@ -306,6 +306,7 @@ def main():
     template_outdir = os.path.join(args.dstdir, tilename_key, 'subtiles')
     template_finfile = "{}_{}.fin".format(template_outdir, target_res)
     template_logfile = os.path.join(bst_logdir, tilename_key+'.log')
+    template_runscript = "{}_startmatlab_{}.sh".format(template_outdir, target_res)
     jobscript_static_args_dict = {
         'system': system_name,
         'scriptdir': SCRIPT_DIR,
@@ -322,6 +323,7 @@ def main():
         'make2m': make2m_arg,
         'finfile': template_finfile,
         'logfile': template_logfile,
+        'runscript': template_runscript,
     }
     jobscript_fname = os.path.basename(args.jobscript)
     jobscript_temp_fname = jobscript_fname.replace(

--- a/qsub_mosaicSubTiles.sh
+++ b/qsub_mosaicSubTiles.sh
@@ -33,6 +33,7 @@ echo
 echo Working directory: $PBS_O_WORKDIR
 echo ________________________________________________________
 echo
+CORES_PER_NODE=$PBS_NUM_PPN
 
 # move to temp folder to reduce startup time
 mkdir -p ~/matlab_temp
@@ -73,15 +74,15 @@ export BWPY_PREFIX=""
 if [ "${p9}" == 'null' ]; then
     echo "Quad arg not present. Running full tile"
 
-    echo matlab -nojvm -nodisplay -nosplash -r "try; addpath('${p1}'); addpath('${p2}'); [x0,x1,y0,y1]=getTileExtents('${p7}','${p8}'); disp(x0); ${p3}('${p4}',${p5},'${p6}','projection','${p11}','version','${p12}','extent',[x0,x1,y0,y1]); catch e; disp(getReport(e)); exit(1); end; exit(0);"
-    time matlab -nojvm -nodisplay -nosplash -r "try; addpath('${p1}'); addpath('${p2}'); [x0,x1,y0,y1]=getTileExtents('${p7}','${p8}'); disp(x0); ${p3}('${p4}',${p5},'${p6}','projection','${p11}','version','${p12}','extent',[x0,x1,y0,y1]); catch e; disp(getReport(e)); exit(1); end; exit(0);"
+    echo matlab -nodisplay -nosplash -r "try; addpath('${p1}'); addpath('${p2}'); warning('off','all'); parpool($CORES_PER_NODE); [x0,x1,y0,y1]=getTileExtents('${p7}','${p8}'); disp(x0); ${p3}('${p4}',${p5},'${p6}','projection','${p11}','version','${p12}','extent',[x0,x1,y0,y1]); catch e; disp(getReport(e)); exit(1); end; exit(0);"
+    time matlab -nodisplay -nosplash -r "try; addpath('${p1}'); addpath('${p2}'); warning('off','all'); parpool($CORES_PER_NODE); [x0,x1,y0,y1]=getTileExtents('${p7}','${p8}'); disp(x0); ${p3}('${p4}',${p5},'${p6}','projection','${p11}','version','${p12}','extent',[x0,x1,y0,y1]); catch e; disp(getReport(e)); exit(1); end; exit(0);"
     task_return_code=$?
 
 else
     echo "Running quadrant ${p9}"
 
-    echo matlab -nojvm -nodisplay -nosplash -r "try; addpath('${p1}'); addpath('${p2}'); [x0,x1,y0,y1]=getTileExtents('${p7}','${p8}','quadrant','${p9}'); ${p3}('${p4}',${p5},'${p6}','projection','${p11}','version','${p12}','quadrant','${p9}','extent',[x0,x1,y0,y1]); catch e; disp(getReport(e)); exit(1); end; exit(0);"
-    time matlab -nojvm -nodisplay -nosplash -r "try; addpath('${p1}'); addpath('${p2}'); [x0,x1,y0,y1]=getTileExtents('${p7}','${p8}','quadrant','${p9}'); ${p3}('${p4}',${p5},'${p6}','projection','${p11}','version','${p12}','quadrant','${p9}','extent',[x0,x1,y0,y1]); catch e; disp(getReport(e)); exit(1); end; exit(0);"
+    echo matlab -nodisplay -nosplash -r "try; addpath('${p1}'); addpath('${p2}'); warning('off','all'); parpool($CORES_PER_NODE); [x0,x1,y0,y1]=getTileExtents('${p7}','${p8}','quadrant','${p9}'); ${p3}('${p4}',${p5},'${p6}','projection','${p11}','version','${p12}','quadrant','${p9}','extent',[x0,x1,y0,y1]); catch e; disp(getReport(e)); exit(1); end; exit(0);"
+    time matlab -nodisplay -nosplash -r "try; addpath('${p1}'); addpath('${p2}'); warning('off','all'); parpool($CORES_PER_NODE); [x0,x1,y0,y1]=getTileExtents('${p7}','${p8}','quadrant','${p9}'); ${p3}('${p4}',${p5},'${p6}','projection','${p11}','version','${p12}','quadrant','${p9}','extent',[x0,x1,y0,y1]); catch e; disp(getReport(e)); exit(1); end; exit(0);"
     task_return_code=$?
 
 fi


### PR DESCRIPTION
- Add call to parpool with the number of cores available on the node as a parameter. 
- One of the loops produces a warning when parallelized that causes the script to think an error occurred. Disable warnings to avoid this.