### PR TITLE
Combined BST+MST job workflow for BW production

### DIFF
--- a/batch_buildSubTiles.py
+++ b/batch_buildSubTiles.py
@@ -17,8 +17,10 @@ SCRIPT_DIR = os.path.dirname(SCRIPT_FILE)
 
 
 ## General argument defaults and settings
+mst_pyscript = os.path.join(SCRIPT_DIR, 'batch_mosaicSubTiles.py')
 default_matlab_scriptdir = os.path.join(SCRIPT_DIR, '../setsm_postprocessing4')
-default_jobscript = os.path.join(SCRIPT_DIR, 'qsub_buildSubTiles.sh')
+default_bst_jobscript = os.path.join(SCRIPT_DIR, 'qsub_buildSubTiles.sh')
+chain_jobscript = os.path.join(SCRIPT_DIR, 'qsub_runBstThenMst.sh')
 default_tempdir = os.path.join(SCRIPT_DIR, 'temp')
 default_logdir = '../logs/[DSTDIR_FOLDER_NAME]'  # relative path appended to argument dstdir
 swift_program = os.path.abspath('/projects/sciteam/bazu/tools/swift-2/bin/swift')
@@ -122,6 +124,8 @@ watermask_tiles_visnav_need_editing_file = os.path.join(SCRIPT_DIR, 'watermask_t
 with open(watermask_tiles_visnav_need_editing_file, 'r') as tilelist_fp:
     watermask_tiles_visnav_need_editing = [line.strip() for line in tilelist_fp.read().splitlines() if line != '']
 
+quads = ['1_1', '1_2', '2_1', '2_2']
+
 
 def main():
 
@@ -179,6 +183,10 @@ def main():
             help="rerun tile without attempting to clean up potentially corrupted subtiles")
     # parser.add_argument("--sort-fix", action="store_true", default=False,
     #         help="run tile with buildSubTilesSortFix script")
+    parser.add_argument("--chain-mst", action='store_true', default=False,
+            help=("Run 10m and 2m mosaicSubTiles processes for each tile after buildSubTiles completes successfully. "
+                  "Delete 'subtiles' folder for the tile upon successful completion of 10m and 2m MST processes. "
+                  "Only 10m MST process will be run if --make-10m-only option is provided."))
 
     # parser.add_argument('--require-finfiles', action='store_true', default=False,
     #         help="let existence of finfiles dictate reruns")
@@ -187,8 +195,8 @@ def main():
     parser.add_argument('--skip-missing-watermasks', action='store_true', default=False,
             help="if tiles are missing watermasks, skip them and submit the rest of the tiles for processing")
 
-    parser.add_argument("--jobscript", default=default_jobscript,
-            help="jobscript used in task submission (default={})".format(default_jobscript))
+    parser.add_argument("--jobscript", default=default_bst_jobscript,
+            help="jobscript used in BST task submission (default={})".format(default_bst_jobscript))
     parser.add_argument("--tempdir", default=default_tempdir,
             help="directory where filled-out running copy of jobscript is created (default={})".format(default_tempdir))
     parser.add_argument("--logdir", default=default_logdir,
@@ -220,6 +228,7 @@ def main():
         tiles = args.tiles.split(',')
     tiles = sorted(list(set(tiles)))
 
+    make_10m_only = 'true' if args.make_10m_only else 'false'
     make2m_arg = 'false' if args.make_10m_only else 'true'
     target_res = '10m' if args.make_10m_only else '2m'
 
@@ -300,6 +309,8 @@ def main():
         parser.error("--pbs --slurm --swift are mutually exclusive")
     if args.rerun and args.rerun_without_cleanup:
         parser.error("--rerun and --rerun-without-cleanup are mutually exclusive")
+    if args.chain_mst and args.project is None:
+        parser.error('--chain-mst option requires --project arg is also provided')
 
     bst_logdir = os.path.join(args.logdir, 'matlab', 'bst', target_res)
     pbs_logdir = os.path.join(args.logdir, 'pbs', 'bst', target_res)
@@ -320,7 +331,8 @@ def main():
             print("Creating output directory: {}".format(outdir))
             os.makedirs(outdir)
 
-    ## Create temp jobscript with comment mosaicking args filled in
+
+    ## Create temp jobscript with mosaicking args filled in
     tilename_key = '<tileName>'
     template_outdir = os.path.join(args.dstdir, tilename_key, 'subtiles')
     template_finfile = "{}_{}.fin".format(template_outdir, target_res)
@@ -364,9 +376,69 @@ def main():
         jobscript_argval = '"{}"'.format(argval)
         jobscript_temp_text = jobscript_temp_text.replace(jobscript_argname, jobscript_argval)
 
-    print("Writing temporary jobscript file: {}".format(jobscript_temp))
+    print("Writing temporary BST jobscript file: {}".format(jobscript_temp))
     with open(jobscript_temp, 'w') as jobscript_fp:
         jobscript_fp.write(jobscript_temp_text)
+    bst_jobscript = jobscript_temp
+
+
+    if args.chain_mst:
+
+        ## Create temp MST jobscript
+        mst_jobscript = None
+        mst_args = ['python', mst_pyscript, args.dstdir, tiles[0], '10', '--project', args.project, '--write-jobscript-and-exit']
+        if not args.make_10m_only:
+            mst_args.append('--make-2m-logdirs')
+        print("Creating MST temporary jobscript file with the following command:\n    {}".format(' '.join(mst_args)))
+        mst_proc = subprocess.Popen(mst_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        mst_stdout, mst_stderr = mst_proc.communicate()
+        mst_stdout = mst_stdout.decode('utf-8').strip()
+        mst_stderr = mst_stderr.decode('utf-8').strip()
+        if mst_stdout != '':
+            print("STDOUT:\n'''\n{}\n'''".format(mst_stdout))
+        if mst_stderr != '':
+            print("STDERR:\n'''\n{}\n'''".format(mst_stderr))
+        mst_out_lines = mst_stdout.splitlines()
+        for line in mst_out_lines:
+            if "Writing temporary jobscript file:" in line:
+                mst_jobscript = line.split(':')[1].strip()
+        if mst_jobscript is None:
+            parser.error("Failed to parse path to MST temporary jobscript from stdout")
+            
+        ## Create temp chain jobscript
+        jobscript_static_args_dict = {
+            'system': system_name,
+            'bst_jobscript': bst_jobscript,
+            'mst_jobscript': mst_jobscript,
+            'mst_pyscript': mst_pyscript,
+            'output_tiles_dir': args.dstdir,
+            'project': args.project,
+            'make_10m_only': make_10m_only,
+        }
+        if not auto_select_arcticdem_water_tile_dir:
+            jobscript_static_args_dict['waterTileDir'] = args.water_tile_dir
+        jobscript_fname = os.path.basename(chain_jobscript)
+        jobscript_temp_fname = jobscript_fname.replace(
+            '.sh',
+            '{}_{}.sh'.format(
+                '_{}'.format(args.project) if args.project is not None else '',
+                datetime.now().strftime("%Y%m%d%H%M%S")
+            )
+        )
+
+        jobscript_temp = os.path.join(args.tempdir, jobscript_temp_fname)
+        with open(chain_jobscript, 'r') as jobscript_fp:
+            jobscript_text = jobscript_fp.read()
+
+        jobscript_temp_text = jobscript_text
+        for argname, argval in jobscript_static_args_dict.items():
+            jobscript_argname = '"$ARG_{}"'.format(argname).upper()
+            jobscript_argval = '"{}"'.format(argval)
+            jobscript_temp_text = jobscript_temp_text.replace(jobscript_argname, jobscript_argval)
+
+        print("Writing temporary chain jobscript file: {}".format(jobscript_temp))
+        with open(jobscript_temp, 'w') as jobscript_fp:
+            jobscript_fp.write(jobscript_temp_text)
 
 
     number_incomplete_tiles = 0
@@ -432,16 +504,17 @@ def main():
                 tiles_missing_watermask.append(tile)
 
         ## If output does not exist, add to task list
-        tile_outdir = os.path.join(args.dstdir, tile, 'subtiles')
-        tile_outdir_exists = os.path.isdir(tile_outdir)
-        if not os.path.isdir(tile_outdir):
+        tile_outdir = os.path.join(args.dstdir, tile)
+        tile_stdir = os.path.join(args.dstdir, tile, 'subtiles')
+        tile_stdir_exists = os.path.isdir(tile_stdir)
+        if not os.path.isdir(tile_stdir):
             if not args.dryrun:
-                os.makedirs(tile_outdir)
+                os.makedirs(tile_stdir)
 
-        final_subtile_fp_10m = os.path.join(tile_outdir, '{}_10000_10m.mat'.format(tile))
-        final_subtile_fp_2m = os.path.join(tile_outdir, '{}_10000_2m.mat'.format(tile))
-        finfile_10m = "{}_10m.fin".format(tile_outdir)
-        finfile_2m = "{}_2m.fin".format(tile_outdir)
+        final_subtile_fp_10m = os.path.join(tile_stdir, '{}_10000_10m.mat'.format(tile))
+        final_subtile_fp_2m = os.path.join(tile_stdir, '{}_10000_2m.mat'.format(tile))
+        finfile_10m = "{}_10m.fin".format(tile_stdir)
+        finfile_2m = "{}_2m.fin".format(tile_stdir)
         if args.make_10m_only:
             final_subtile_fp = final_subtile_fp_10m
             finfile = finfile_10m
@@ -451,38 +524,64 @@ def main():
 
         run_tile = True
 
-        if tile_outdir_exists:
+        mst_complete = False
+        if args.chain_mst:
+            mst_complete = True
+            mst_finfile_10m = os.path.join(tile_outdir, '{}_10m.fin'.format(tile))
+            if not os.path.isfile(mst_finfile_10m):
+                mst_complete = False
+            if not args.make_10m_only:
+                for q in quads:
+                    mst_finfile_2m = os.path.join(tile_outdir, '{}_{}_2m.fin'.format(tile, q))
+                    if not os.path.isfile(mst_finfile_2m):
+                        mst_complete = False
+                        break
+            if mst_complete:
+                if args.make_10m_only:
+                    print("Tile {} seems complete (MST 10m finfile exists)".format(tile))
+                else:
+                    print("Tile {} seems complete (MST 10m and 2m quad finfiles exist)".format(tile))
+                run_tile = False
+
+        if run_tile:
             # if args.sort_fix or args.rerun_without_cleanup:
             if args.rerun_without_cleanup:
                 pass
 
             elif args.rerun:
-                print("Verifying tile {} before rerun".format(tile))
+                print("Verifying tile {} BST results before rerun".format(tile))
 
+                bst_complete = False
                 # if os.path.isfile(final_subtile_fp) and not args.require_finfiles:
                 if os.path.isfile(final_subtile_fp) and args.bypass_finfile_req:
-                    print("Tile seems complete ({} exists)".format(os.path.basename(final_subtile_fp)))
-                    run_tile = False
+                    print("Tile seems complete with BST step ({} exists)".format(os.path.basename(final_subtile_fp)))
+                    bst_complete = True
                 elif os.path.isfile(finfile):
-                    print("Tile seems complete ({} exists)".format(os.path.basename(finfile)))
-                    run_tile = False
+                    print("Tile seems complete with BST step ({} exists)".format(os.path.basename(finfile)))
+                    bst_complete = True
                 elif os.path.isfile(finfile_2m):
-                    print("Tile seems complete (2m finfile {} exists)".format(os.path.basename(finfile_2m)))
-                    run_tile = False
+                    print("Tile seems complete with BST step (2m finfile {} exists)".format(os.path.basename(finfile_2m)))
+                    bst_complete = True
 
-                # if not args.make_10m_only:
+                # if tile_stdir_exists and not args.make_10m_only:
                 #     ## Remove subtiles with only 10m version
-                #     tile_outfiles_10m = glob.glob(os.path.join(tile_outdir, '{}_*10m.mat'.format(tile)))
+                #     tile_outfiles_10m = glob.glob(os.path.join(tile_stdir, '{}_*10m.mat'.format(tile)))
                 #     for outfile_10m in tile_outfiles_10m:
                 #         outfile_2m = outfile_10m.replace('10m.mat', '2m.mat')
                 #         if not os.path.isfile(outfile_2m):
                 #             print("Removing 10m subtile missing 2m component: {}".format(os.path.basename(outfile_10m)))
-                #             run_tile = True
+                #             bst_complete = False
                 #             if not args.dryrun:
                 #                 os.remove(outfile_10m)
 
-            elif any(os.scandir(tile_outdir)):
-                print("Subtiles exist, skipping tile {}".format(tile))
+                if args.chain_mst and not mst_complete:
+                    if bst_complete:
+                        print("... but MST step is not complete, so tile will be run")
+                elif bst_complete:
+                    run_tile = False
+
+            elif tile_stdir_exists and any(os.scandir(tile_stdir)):
+                print("Subtiles exist, skipping BST step for tile {}".format(tile))
                 run_tile = False
 
         if run_tile:
@@ -523,6 +622,9 @@ def main():
     sleep_seconds = 10
     print("Sleeping {} seconds before submission".format(sleep_seconds))
     time.sleep(sleep_seconds)
+
+    task_success_rc = 3 if len(tiles_to_run) > 0 else -1
+    matlab_cmd_success = None
 
     if args.swift:
         with open(swift_tasklist_file, 'w') as swift_tasklist_fp:
@@ -580,14 +682,19 @@ def main():
                 )
 
             else:
-                cmd = r""" bash "{}" {} """.format(
+                cmd = r""" {}bash "{}" {} """.format(
+                    'export ARG_WATERTILEDIR="{}"'.format(arg_waterTileDir) if arg_waterTileDir is not None else '',
                     jobscript_temp,
                     tile,
                 )
 
             print("{}, {}".format(tasknum, cmd))
             if not args.dryrun:
-                subprocess.call(cmd, shell=True, cwd=(pbs_logdir if args.pbs else None))
+                matlab_cmd_rc = subprocess.call(cmd, shell=True, cwd=(pbs_logdir if args.pbs else None))
+                if matlab_cmd_rc == 2 and matlab_cmd_success is not False:
+                    matlab_cmd_success = True
+                else:
+                    matlab_cmd_success = False
 
         if args.pbs or args.slurm:
             print("Submitted {} tiles to scheduler".format(number_run_tiles_text))
@@ -602,6 +709,13 @@ def main():
             print("!!! WARNING !!! {} INCOMPLETE tiles are missing watermasks:\n{}\n".format(
                 len(incomplete_tiles_missing_watermask), '\n'.join(incomplete_tiles_missing_watermask))
             )
+
+    if matlab_cmd_success is True:
+        task_success_rc = 2
+    elif matlab_cmd_success is False:
+        task_success_rc = 1
+
+    sys.exit(task_success_rc)
 
 
 

--- a/batch_buildSubTiles.py
+++ b/batch_buildSubTiles.py
@@ -507,7 +507,7 @@ def main():
         tile_outdir = os.path.join(args.dstdir, tile)
         tile_stdir = os.path.join(args.dstdir, tile, 'subtiles')
         tile_stdir_exists = os.path.isdir(tile_stdir)
-        if not os.path.isdir(tile_stdir):
+        if not args.chain_mst and not os.path.isdir(tile_stdir):
             if not args.dryrun:
                 os.makedirs(tile_stdir)
 

--- a/batch_buildSubTiles_bw.patch
+++ b/batch_buildSubTiles_bw.patch
@@ -1,8 +1,8 @@
 diff --git a/batch_buildSubTiles.py b/batch_buildSubTiles.py
-index 9873178..7c94432 100644
+index d82842c..067ac33 100644
 --- a/batch_buildSubTiles.py
 +++ b/batch_buildSubTiles.py
-@@ -76,40 +76,40 @@ project_epsg_dict = {
+@@ -78,40 +78,40 @@ project_epsg_dict = {
  earthdem_tilePrefix_key = '<tilePrefix>'
  project_refDemFile_dict = {
      'arcticdem': None,

--- a/batch_mosaicSubTiles.py
+++ b/batch_mosaicSubTiles.py
@@ -294,7 +294,7 @@ def main():
     if args.chain_mst_jobscript is not None:
         jobscript_temp = args.chain_mst_jobscript
     else:
-        ## Create temp jobscript with comment mosaicking args filled in
+        ## Create temp jobscript with mosaicking args filled in
         supertilename_key = '<superTileName>'
         outtilename_key = '<outTileName>'
         resolution_key = '<resolution>'

--- a/batch_mosaicSubTiles.py
+++ b/batch_mosaicSubTiles.py
@@ -145,10 +145,14 @@ def main():
 
     parser.add_argument("--jobscript", default=default_jobscript,
             help="jobscript used in task submission (default={})".format(default_jobscript))
+    parser.add_argument("--chain-mst-jobscript", default=None,
+            help="filled-out MST jobscript, this arg should only be used by BST --chain-mst option")
     parser.add_argument("--tempdir", default=default_tempdir,
             help="directory where filled-out running copy of jobscript is created (default={})".format(default_tempdir))
     parser.add_argument("--logdir", default=default_logdir,
             help="directory where logfiles for Matlab tile processing are created (default is {} from srcdir)".format(default_logdir))
+    parser.add_argument("--make-2m-logdirs", action='store_true', default=False,
+            help="create 2m logdir directories if they do not exist")
 
     parser.add_argument("--queue", default=sched_default_queue,
             help="queue for scheduler submission")
@@ -171,10 +175,14 @@ def main():
             help="Print tile-submission commands without executing")
     parser.add_argument("--dryrun", action='store_true', default=False,
             help="Print actions without executing")
+    parser.add_argument("--write-jobscript-and-exit", action='store_true', default=False,
+            help="Write filled-out running copy of jobscript and then exit")
 
     args = parser.parse_args()
-    if (not args.submit) or args.test_submit:
-        args.dryrun = True
+    if ((not args.submit) or args.test_submit) and (not args.dryrun):
+        real_submit = True
+    else:
+        real_submit = False
 
     if os.path.isfile(args.tiles):
         tilelist_file = args.tiles
@@ -241,6 +249,8 @@ def main():
         parser.error("--libdir does not exist: {}".format(args.libdir))
     if not os.path.isfile(args.jobscript):
         parser.error("--jobscript does not exist: {}".format(args.jobscript))
+    if args.chain_mst_jobscript is not None and not os.path.isfile(args.chain_mst_jobscript):
+        parser.error("--chain-mst-jobscript does not exist: {}".format(args.chain_mst_jobscript))
 
     ## Verify other arguments
     if [args.pbs, args.slurm, args.swift].count(True) > 1:
@@ -248,80 +258,90 @@ def main():
     if args.bypass_bst_finfile_req and args.relax_bst_finfile_req:
         parser.error("--bypass-bst-finfile-req and --relax-bst-finfile-req arguments are mutually exclusive")
 
+    res_list = [target_res]
+    if args.make_2m_logdirs and target_res != '2m':
+        res_list.insert(0, '2m')
     log_time = datetime.now().strftime("%Y%m%d%H%M%S")
-    mst_logdir = os.path.join(args.logdir, 'matlab', 'mst', target_res)
-    pbs_logdir = os.path.join(args.logdir, 'pbs', 'mst', target_res)
-    if batch_job_submission:
-        pbs_logdir = '{}_batch_{}_{}-tiles'.format(pbs_logdir, log_time, len(tiles))
-    swift_logrootdir = os.path.join(args.logdir, 'swift')
-    swift_logdir = os.path.join(swift_logrootdir, 'mst', target_res)
-    swift_tasklist_dir = os.path.join(swift_logrootdir, 'tasklist')
-    swift_tasklist_fname = 'mst_{}_tasklist_{}.txt'.format(target_res, datetime.now().strftime("%Y%m%d%H%M%S"))
-    swift_tasklist_file = os.path.join(swift_tasklist_dir, swift_tasklist_fname)
+    for res in res_list:
+        template_mst_logdir = os.path.join(args.logdir, 'matlab', 'mst', res)
+        mst_logdir = os.path.join(args.logdir, 'matlab', 'mst', res)
+        pbs_logdir = os.path.join(args.logdir, 'pbs', 'mst', res)
+        if batch_job_submission and res == target_res:
+            pbs_logdir = '{}_batch_{}_{}-tiles'.format(pbs_logdir, log_time, len(tiles))
+        swift_logrootdir = os.path.join(args.logdir, 'swift')
+        swift_logdir = os.path.join(swift_logrootdir, 'mst', res)
+        swift_tasklist_dir = os.path.join(swift_logrootdir, 'tasklist')
+        swift_tasklist_fname = 'mst_{}_tasklist_{}.txt'.format(res, datetime.now().strftime("%Y%m%d%H%M%S"))
+        swift_tasklist_file = os.path.join(swift_tasklist_dir, swift_tasklist_fname)
 
-    ## Create output directories
-    outdir_list = [args.tempdir, mst_logdir]
-    if args.pbs:
-        outdir_list.append(pbs_logdir)
-    if args.swift:
-        outdir_list.extend([swift_rundir, swift_logdir, swift_tasklist_dir])
-    if not args.dryrun:
-        for outdir in outdir_list:
-            if not os.path.isdir(outdir):
-                print("Creating output directory: {}".format(outdir))
-                os.makedirs(outdir)
-        if batch_job_submission:
-            pbs_batch_tilelist = os.path.join(pbs_logdir, 'tilelist.txt')
-            with open(pbs_batch_tilelist, 'w') as tilelist_fp:
-                for tile in tiles:
-                    tilelist_fp.write(tile+'\n')
+        ## Create output directories
+        outdir_list = [args.tempdir, mst_logdir]
+        if args.pbs:
+            outdir_list.append(pbs_logdir)
+        if args.swift:
+            outdir_list.extend([swift_rundir, swift_logdir, swift_tasklist_dir])
+        if not args.dryrun:
+            for outdir in outdir_list:
+                if not os.path.isdir(outdir):
+                    print("Creating output directory: {}".format(outdir))
+                    os.makedirs(outdir)
+            if batch_job_submission and res == target_res:
+                pbs_batch_tilelist = os.path.join(pbs_logdir, 'tilelist.txt')
+                with open(pbs_batch_tilelist, 'w') as tilelist_fp:
+                    for tile in tiles:
+                        tilelist_fp.write(tile+'\n')
 
-    ## Create temp jobscript with comment mosaicking args filled in
-    supertilename_key = '<superTileName>'
-    outtilename_key = '<outTileName>'
-    template_subtiledir = os.path.join(args.srcdir, supertilename_key, 'subtiles')
-    template_outmatfile = os.path.join(args.srcdir, supertilename_key, "{}_{}.mat".format(outtilename_key, target_res))
-    template_finfile = os.path.join(args.srcdir, supertilename_key, "{}_{}.fin".format(outtilename_key, target_res))
-    template_logfile = os.path.join(mst_logdir, outtilename_key+'.log')
-    jobscript_static_args_dict = {
-        'system': system_name,
-        'scriptdir': SCRIPT_DIR,
-        'libdir': args.libdir,
-        'tileDefFile': args.tile_def,
-        'subTileDir': template_subtiledir,
-        'resolution': args.res,
-        'outMatFile': template_outmatfile,
-        'projection': projection_string,
-        'version': args.version,
-        'exportTif': 'true' if args.export_tif else 'false',
-        'finfile': template_finfile,
-        'logfile': template_logfile,
-    }
-    jobscript_fname = os.path.basename(args.jobscript)
-    jobscript_temp_fname = jobscript_fname.replace(
-        '.sh',
-        '{}_{}.sh'.format(
-            '_{}'.format(args.project) if args.project is not None else '',
-            datetime.now().strftime("%Y%m%d%H%M%S")
+    if args.chain_mst_jobscript is not None:
+        jobscript_temp = args.chain_mst_jobscript
+    else:
+        ## Create temp jobscript with comment mosaicking args filled in
+        supertilename_key = '<superTileName>'
+        outtilename_key = '<outTileName>'
+        resolution_key = '<resolution>'
+        template_subtiledir = os.path.join(args.srcdir, supertilename_key, 'subtiles')
+        template_outmatfile = os.path.join(args.srcdir, supertilename_key, "{}_{}.mat".format(outtilename_key, resolution_key))
+        template_finfile = os.path.join(args.srcdir, supertilename_key, "{}_{}.fin".format(outtilename_key, resolution_key))
+        template_logfile = os.path.join(os.path.join(args.logdir, 'matlab', 'mst', resolution_key), outtilename_key+'.log')
+        jobscript_static_args_dict = {
+            'system': system_name,
+            'scriptdir': SCRIPT_DIR,
+            'libdir': args.libdir,
+            'tileDefFile': args.tile_def,
+            'subTileDir': template_subtiledir,
+            'resolution': args.res,
+            'outMatFile': template_outmatfile,
+            'projection': projection_string,
+            'version': args.version,
+            'exportTif': 'true' if args.export_tif else 'false',
+            'finfile': template_finfile,
+            'logfile': template_logfile,
+        }
+        jobscript_fname = os.path.basename(args.jobscript)
+        jobscript_temp_fname = jobscript_fname.replace(
+            '.sh',
+            '{}_{}.sh'.format(
+                '_{}'.format(args.project) if args.project is not None else '',
+                datetime.now().strftime("%Y%m%d%H%M%S")
+            )
         )
-    )
 
-    jobscript_temp = os.path.join(args.tempdir, jobscript_temp_fname)
-    with open(args.jobscript, 'r') as jobscript_fp:
-        jobscript_text = jobscript_fp.read()
+        jobscript_temp = os.path.join(args.tempdir, jobscript_temp_fname)
+        with open(args.jobscript, 'r') as jobscript_fp:
+            jobscript_text = jobscript_fp.read()
 
-    jobscript_temp_text = jobscript_text
-    for argname, argval in jobscript_static_args_dict.items():
-        jobscript_argname = '"$ARG_{}"'.format(argname).upper()
-        jobscript_argval = '"{}"'.format(argval)
-        jobscript_temp_text = jobscript_temp_text.replace(jobscript_argname, jobscript_argval)
+        jobscript_temp_text = jobscript_text
+        for argname, argval in jobscript_static_args_dict.items():
+            jobscript_argname = '"$ARG_{}"'.format(argname).upper()
+            jobscript_argval = '"{}"'.format(argval)
+            jobscript_temp_text = jobscript_temp_text.replace(jobscript_argname, jobscript_argval)
 
-    print("Writing temporary jobscript file: {}".format(jobscript_temp))
-    with open(jobscript_temp, 'w') as jobscript_fp:
-        jobscript_fp.write(jobscript_temp_text)
+        print("Writing temporary jobscript file: {}".format(jobscript_temp))
+        with open(jobscript_temp, 'w') as jobscript_fp:
+            jobscript_fp.write(jobscript_temp_text)
+        if args.write_jobscript_and_exit:
+            sys.exit(0)
 
     tilerun_jobscript = jobscript_temp
-
 
 
     tiles_to_run = []
@@ -336,7 +356,6 @@ def main():
                 tasks.append(Task(tile, 'null'))
 
     print("{} {}tiles to check".format(len(tasks), 'quad-' if args.quads else ''))
-    num_tiles_to_run = 0
 
     error_messages = []
     supertile_num_nodata_dict = dict()
@@ -440,8 +459,8 @@ def main():
                 dstfps_old_pattern = dstfp.replace('.mat', '*')
                 dstfps_old = glob.glob(dstfps_old_pattern)
                 if dstfps_old:
-                    print("{}Removing old MST results matching {}".format('(dryrun) ' if args.dryrun else '', dstfps_old_pattern))
-                    if not args.dryrun:
+                    print("{}Removing old MST results matching {}".format('(dryrun) ' if not real_submit else '', dstfps_old_pattern))
+                    if real_submit:
                         for dstfp_old in dstfps_old:
                             os.remove(dstfp_old)
                 run_tile = True
@@ -466,6 +485,8 @@ def main():
             if run_tile:
                 tiles_to_run.append(outtile)
 
+    task_success_rc = 3 if len(tiles_to_run) > 0 else -1
+    matlab_cmd_success = None
 
     ran_tiles = False
     if len(tiles_to_run) > 0 and (args.submit or args.test_submit):
@@ -550,7 +571,11 @@ def main():
 
                 print("{}, {}".format(jobnum, cmd))
                 if not args.dryrun:
-                    subprocess.call(cmd, shell=True, cwd=(pbs_logdir if args.pbs else None))
+                    matlab_cmd_rc = subprocess.call(cmd, shell=True, cwd=(pbs_logdir if args.pbs else None))
+                    if matlab_cmd_rc == 2 and matlab_cmd_success is not False:
+                        matlab_cmd_success = True
+                    else:
+                        matlab_cmd_success = False
 
             if args.pbs or args.slurm:
                 print("Submitted {} {}tiles to scheduler".format(len(tiles_to_run), 'quad-' if args.quads else ''))
@@ -593,6 +618,13 @@ def main():
 
     if len(tiles_to_run) > 0 and not args.submit:
         print("Provide the --submit option to run tiles")
+
+    if matlab_cmd_success is True:
+        task_success_rc = 2
+    elif matlab_cmd_success is False:
+        task_success_rc = 1
+
+    sys.exit(task_success_rc)
 
 
 

--- a/batch_mosaicSubTiles_bw.patch
+++ b/batch_mosaicSubTiles_bw.patch
@@ -1,8 +1,8 @@
 diff --git a/batch_mosaicSubTiles.py b/batch_mosaicSubTiles.py
-index ec2de1f..ab555fe 100644
+index 19b7879..6bb46fa 100644
 --- a/batch_mosaicSubTiles.py
 +++ b/batch_mosaicSubTiles.py
-@@ -76,9 +76,9 @@ project_epsg_dict = {
+@@ -78,9 +78,9 @@ project_epsg_dict = {
  
  earthdem_hemisphere_key = '<hemisphere>'
  project_tileDefFile_dict = {

--- a/qsub_batchRunTiles.sh
+++ b/qsub_batchRunTiles.sh
@@ -9,6 +9,5 @@ total_ntiles=${#tilelist_arr[@]}
 for tile_idx in "${!tilelist_arr[@]}"; do
     tile="${tilelist_arr[$tile_idx]}"
     echo -e "\n\nRunning tile $((tile_idx+1)) of ${total_ntiles}: ${tile}"
-    export ARG_TILENAME="$tile"
-    bash "$tilerun_jobscript"
+    bash "$tilerun_jobscript" "$tile"
 done

--- a/qsub_buildSubTiles.sh
+++ b/qsub_buildSubTiles.sh
@@ -101,7 +101,9 @@ logfile="$ARG_LOGFILE"
 runscript="$ARG_RUNSCRIPT"
 
 if (( $# == 1 )); then
-    if [ -z "$tileName" ]; then
+    if [ "$1" = '--make-10m-only' ]; then
+        make2m=false
+    elif [ -z "$tileName" ]; then
         tileName="$1"
     fi
 fi

--- a/qsub_mosaicSubTiles.sh
+++ b/qsub_mosaicSubTiles.sh
@@ -145,20 +145,20 @@ else
     echo "Running full supertile ${tileName}"
 fi
 
-subTileDir="${subTileDir/<superTileName>/${superTileName}}"
-outMatFile="${outMatFile/<superTileName>/${superTileName}}"
-finfile="${finfile/<superTileName>/${superTileName}}"
-logfile="${logfile/<superTileName>/${superTileName}}"
+subTileDir="${subTileDir//<superTileName>/${superTileName}}"
+outMatFile="${outMatFile//<superTileName>/${superTileName}}"
+finfile="${finfile//<superTileName>/${superTileName}}"
+logfile="${logfile//<superTileName>/${superTileName}}"
 
-subTileDir="${subTileDir/<outTileName>/${outTileName}}"
-outMatFile="${outMatFile/<outTileName>/${outTileName}}"
-finfile="${finfile/<outTileName>/${outTileName}}"
-logfile="${logfile/<outTileName>/${outTileName}}"
+subTileDir="${subTileDir//<outTileName>/${outTileName}}"
+outMatFile="${outMatFile//<outTileName>/${outTileName}}"
+finfile="${finfile//<outTileName>/${outTileName}}"
+logfile="${logfile//<outTileName>/${outTileName}}"
 
-subTileDir="${subTileDir/<resolution>/${resolution}}"
-outMatFile="${outMatFile/<resolution>/${resolution}}"
-finfile="${finfile/<resolution>/${resolution}}"
-logfile="${logfile/<resolution>/${resolution}}"
+subTileDir="${subTileDir//<resolution>/${resolution}m}"
+outMatFile="${outMatFile//<resolution>/${resolution}m}"
+finfile="${finfile//<resolution>/${resolution}m}"
+logfile="${logfile//<resolution>/${resolution}m}"
 
 
 # System-specific settings

--- a/qsub_mosaicSubTiles.sh
+++ b/qsub_mosaicSubTiles.sh
@@ -82,24 +82,26 @@ CORES_PER_NODE=$PBS_NUM_PPN
 #CORES_PER_NODE=$SLURM_CPUS_ON_NODE
 set -u
 
-set +u
+set +u; tileName="$ARG_TILENAME"; set -u
+resolution="$ARG_RESOLUTION"
 system="$ARG_SYSTEM"
 scriptdir="$ARG_SCRIPTDIR"
 libdir="$ARG_LIBDIR"
-tileName="$ARG_TILENAME"
 tileDefFile="$ARG_TILEDEFFILE"
 subTileDir="$ARG_SUBTILEDIR"
-resolution="$ARG_RESOLUTION"
 outMatFile="$ARG_OUTMATFILE"
 projection="$ARG_PROJECTION"
 version="$ARG_VERSION"
 exportTif="$ARG_EXPORTTIF"
 finfile="$ARG_FINFILE"
 logfile="$ARG_LOGFILE"
-set -u
 
-if [ -z "$tileName" ]; then
-    tileName="$1"
+if (( $# == 1 )); then
+    if [ -z "$tileName" ]; then
+        tileName="$1"
+    else
+        resolution="$1"
+    fi
 fi
 if [ -z "$tileName" ]; then
     echo "argument 'tileName' not supplied, exiting"
@@ -152,6 +154,11 @@ subTileDir="${subTileDir/<outTileName>/${outTileName}}"
 outMatFile="${outMatFile/<outTileName>/${outTileName}}"
 finfile="${finfile/<outTileName>/${outTileName}}"
 logfile="${logfile/<outTileName>/${outTileName}}"
+
+subTileDir="${subTileDir/<resolution>/${resolution}}"
+outMatFile="${outMatFile/<resolution>/${resolution}}"
+finfile="${finfile/<resolution>/${resolution}}"
+logfile="${logfile/<resolution>/${resolution}}"
 
 
 # System-specific settings
@@ -269,8 +276,8 @@ task_return_code=$?
 echo
 echo "Task return code: ${task_return_code}"
 if [ ! -f "$logfile" ]; then
-    log_error=''
-    echo "WARNING! Logfile does not exist: ${logfile}"
+    log_error="ERROR! Logfile does not exist: ${logfile}"
+    echo "$log_error"
     echo "Cannot check logfile for potential errmsgs from task"
 else
     log_error=$(grep -i -m1 'error' "$logfile")
@@ -283,29 +290,38 @@ else
 fi
 echo
 
-# Create finfile if Matlab command exited without error
-if (( task_return_code == 0 )) && [ -z "$log_error" ]; then
-    echo "Considering run successful due to [task return code of zero] AND [no errmsgs found in logfile]"
 
-    if [ "$exportTif" = false ]; then
-        echo "Removing unneeded tile result metadata files, since 'exportTif' argument is false"
-        tileRegFile="${outMatFile/.mat/tileReg.mat}"
-        tileMetaFile="${outMatFile/.mat/_meta.txt}"
+tileRegFile="${outMatFile/.mat/tileReg.mat}"
+tileMetaFile="${outMatFile/.mat/_meta.txt}"
+if [ "$exportTif" = false ] && { [ -f "$tileRegFile" ] || [ -f "$tileMetaFile" ]; }; then
+    echo "Removing unneeded tile result metadata files, since 'exportTif' argument is false"
+    if [ -f "$tileRegFile" ]; then
         rm -vf "$tileRegFile"
+    fi
+    if [ -f "$tileMetaFile" ]; then
         rm -vf "$tileMetaFile"
     fi
-
-    echo "Creating finfile: ${finfile}"
-    touch "$finfile"
-else
-    echo "Considering run unsuccessful due to either [non-zero task return code] OR [errmsgs found in logfile]"
-    echo "Will not create finfile"
+    echo
 fi
 
+
+# Create finfile if Matlab command exited without error
+if (( task_return_code == 0 )) && [ -z "$log_error" ]; then
+    echo -e "\nConsidering run successful due to [task return code of zero] AND [no errmsgs found in logfile]"
+    echo "Creating finfile: ${finfile}"
+    touch "$finfile"
+    exit_status=2
+else
+    echo -e "\nConsidering run unsuccessful due to either [non-zero task return code] OR [logfile DNE] OR [errmsgs found in logfile]"
+    echo "Will not create finfile"
+    exit_status=1
+fi
+
+echo
 if [ "$MATLAB_USE_PARPOOL" = true ] && [ -d "$job_temp_dir" ]; then
     echo "Removing Matlab temp dir for parallel tasks: ${job_temp_dir}"
     rm -rf "$job_temp_dir"
 fi
 
-echo
 echo "Done"
+exit "$exit_status"

--- a/qsub_runBstThenMst.sh
+++ b/qsub_runBstThenMst.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+## PGC settings
+##PBS -l walltime=200:00:00,nodes=1:ppn=16,mem=64gb
+##PBS -m n
+##PBS -k oe
+##PBS -j oe
+##PBS -q old
+
+## BW settings
+##PBS -l nodes=1:ppn=16:xe,gres=shifter
+##PBS -l walltime=96:00:00
+##PBS -v CRAY_ROOTFS=SHIFTER,UDI="ubuntu:xenial"
+##PBS -e $PBS_JOBID.err
+##PBS -o $PBS_JOBID.out
+##PBS -m n
+##PBS -q high
+
+
+set -uo pipefail
+
+set +u; tileName="$ARG_TILENAME" ; set -u
+system="$ARG_SYSTEM"
+bst_jobscript="$ARG_BST_JOBSCRIPT"
+mst_jobscript="$ARG_MST_JOBSCRIPT"
+mst_pyscript="$ARG_MST_PYSCRIPT"
+output_tiles_dir="$ARG_OUTPUT_TILES_DIR"
+project="$ARG_PROJECT"
+waterTileDir="$ARG_WATERTILEDIR"
+make_10m_only="$ARG_MAKE_10M_ONLY"
+
+if [ -z "$tileName" ]; then
+    tileName="$1"
+fi
+if [ -z "$tileName" ]; then
+    echo "argument 'tileName' not supplied, exiting"
+    exit 0
+fi
+
+tile_subtiles_dir="${output_tiles_dir}/${tileName}/subtiles/"
+bst_finfile_10m="${output_tiles_dir}/${tileName}/subtiles_10m"
+bst_finfile_2m="${output_tiles_dir}/${tileName}/subtiles_2m"
+
+
+#if [ "$system" = 'pgc' ]; then
+#    module load gdal/2.1.3
+#    python_exec='python'
+#elif [ "$system" = 'bw' ]; then
+#    module load bwpy/2.0.2
+#    python_exec='bwpy-environ -- python'
+#fi
+
+bst_cmd="bash \"${bst_jobscript}\""
+#mst_cmd_base="${python_exec} \"${mst_pyscript}\" \"${output_tiles_dir}\" ${tileName} --project ${project} --chain-mst-jobscript \"${mst_jobscript}\" --submit"
+#mst_cmd_10m="${mst_cmd_base} 10"
+#mst_cmd_2m="${mst_cmd_base} 2 --quads"
+mst_cmd_base="bash \"${mst_jobscript}\""
+mst_cmd_10m="${mst_cmd_base} 10"
+mst_cmd_2m="${mst_cmd_base} 2"
+quads_arr=( '1_1' '1_2' '2_1' '2_2' )
+
+
+run_bst=true
+if [ "$make_10m_only" = true ]; then
+    if [ -f "$bst_finfile_10m" ] || [ -f "$bst_finfile_2m" ]; then
+        run_bst=false
+    fi
+else
+    if [ -f "$bst_finfile_2m" ]; then
+        run_bst=false
+    fi
+fi
+if [ "$run_bst" = true ]; then
+    bst_txt="BST then "
+else
+    bst_txt=''
+fi
+if [ "$make_10m_only" = true ]; then
+    echo "Will run ${bst_txt}MST 10m for tile: ${tileName}"
+else
+    echo "Will run ${bst_txt}MST 10m and 2m for tile: ${tileName}"
+fi
+
+
+if [ "$run_bst" = true ]; then
+    cmd="$bst_cmd"
+    echo "Running BST process with command: ${cmd}"
+    export ARG_TILENAME="$tileName"
+    export ARG_WATERTILEDIR="$waterTileDir"
+    eval "$cmd"
+    cmd_status=$?
+    if (( cmd_status != 2 )); then
+        echo "BST jobscript exited with non-success(2) exit status (${cmd_status})"
+        exit
+    fi
+fi
+
+cmd="${mst_cmd_10m}"
+echo "Running 10m MST process with command: ${cmd}"
+export ARG_TILENAME="$tileName"
+eval "$cmd"
+cmd_status=$?
+if (( cmd_status != 2 )); then
+    echo "MST jobscript exited with non-success(2) exit status (${cmd_status})"
+    exit
+fi
+
+if [ "$make_10m_only" = false ]; then
+    cmd="${mst_cmd_2m}"
+    for quad in "${quads_arr[@]}"; do
+        quadTileName="${tileName}_${quad}"
+        echo "Running 2m MST process with command: ${cmd}"
+        export ARG_TILENAME="$quadTileName"
+        eval "$cmd"
+        cmd_status=$?
+        if (( cmd_status != 2 )); then
+            echo "MST jobscript exited with non-success(2) exit status (${cmd_status})"
+            exit
+        fi
+    done
+fi
+
+
+if [ ! -d "$tile_subtiles_dir" ]; then
+    echo "Cannot remove tile subtiles directory, it does not exist: ${tile_subtiles_dir}"
+else
+    echo "Removing tile subtiles directory: ${tile_subtiles_dir}"
+    rm -rf "$tile_subtiles_dir"
+fi

--- a/qsub_runBstThenMst.sh
+++ b/qsub_runBstThenMst.sh
@@ -148,6 +148,10 @@ fi
 # BST step
 bst_failure=false
 if [ "$run_bst" = true ]; then
+    if [ ! -d "$tile_subtiles_dir" ]; then
+        echo "Creating tile subtiles dir: ${tile_subtiles_dir}"
+        mkdir -p "$tile_subtiles_dir"
+    fi
     cmd="$bst_cmd"
     echo "Running BST process with command: ${cmd}"
     export ARG_TILENAME="$tileName"


### PR DESCRIPTION
Running batch_buildSubTiles.py with the new `--chain-mst` option will kick off a single job for each input tile that attempts to completely run the BST step, followed by MST 10m and all four MST 2m quad steps. After all is complete, the tile's subtiles folder will be removed.