### PR TITLE
Alter BST+MST workflow to reduce strain on BW scheduler and filesystem

### DIFF
--- a/batch_buildSubTiles.py
+++ b/batch_buildSubTiles.py
@@ -2,6 +2,7 @@
 
 import argparse
 import glob
+import math
 import os
 import socket
 import subprocess
@@ -21,6 +22,7 @@ mst_pyscript = os.path.join(SCRIPT_DIR, 'batch_mosaicSubTiles.py')
 default_matlab_scriptdir = os.path.join(SCRIPT_DIR, '../setsm_postprocessing4')
 default_bst_jobscript = os.path.join(SCRIPT_DIR, 'qsub_buildSubTiles.sh')
 chain_jobscript = os.path.join(SCRIPT_DIR, 'qsub_runBstThenMst.sh')
+batch_jobscript = os.path.join(SCRIPT_DIR, 'qsub_batchRunTiles.sh')
 default_tempdir = os.path.join(SCRIPT_DIR, 'temp')
 default_logdir = '../logs/[DSTDIR_FOLDER_NAME]'  # relative path appended to argument dstdir
 swift_program = os.path.abspath('/projects/sciteam/bazu/tools/swift-2/bin/swift')
@@ -44,7 +46,7 @@ elif hostname.startswith('nunatak'):
     sched_presubmit_cmd = ''
     sched_addl_envvars = ''
     sched_specify_outerr_paths = False
-    sched_addl_vars = "-l walltime=200:00:00,nodes=1:ppn=16,mem=64gb -m n -k oe -j oe"
+    sched_addl_vars = "-l nodes=1:ppn=16,mem=64gb,walltime=200:00:00 -m n -k oe -j oe"
     sched_default_queue = 'old'
 else:
     warnings.warn("Hostname '{}' not recognized. System-specific settings will not be applied.".format(hostname))
@@ -128,6 +130,7 @@ quads = ['1_1', '1_2', '2_1', '2_2']
 
 
 def main():
+    global sched_addl_vars
 
     parser = argparse.ArgumentParser()
     parser.add_argument("dstdir", help="target directory (where tile subfolders will be created)")
@@ -189,6 +192,8 @@ def main():
                   "Only 10m MST process will be run if --make-10m-only option is provided."))
     parser.add_argument("--chain-mst-keep-subtiles", action='store_true', default=False,
             help="do not remove tiles' 'subtiles' folders after successful BST+MST steps")
+    parser.add_argument("--chain-mst-no-local", action='store_true', default=False,
+            help="do not use local space on compute nodes for tiles' 'subtiles' folders")
 
     # parser.add_argument('--require-finfiles', action='store_true', default=False,
     #         help="let existence of finfiles dictate reruns")
@@ -217,6 +222,8 @@ def main():
     parser.add_argument("--swift-logdir", default=None,
             help="directory where output job logs from Swift will go (default is ../logs/ from dstdir)")
 
+    parser.add_argument("--tasks-per-job", type=int, default=1,
+            help="Number of tiles to run in a single PBS or Slurm job")
     parser.add_argument("--dryrun", action='store_true', default=False,
             help='print actions without executing')
 
@@ -233,6 +240,21 @@ def main():
     make_10m_only = 'true' if args.make_10m_only else 'false'
     make2m_arg = 'false' if args.make_10m_only else 'true'
     target_res = '10m' if args.make_10m_only else '2m'
+
+    if args.tasks_per_job > 1:
+        if not (args.pbs or args.slurm):
+            parser.error("--tasks-per-job > 1 can only be provided in addition to"
+                         " --pbs or --slurm scheduler job submission options")
+        batch_job_submission = True
+        if args.pbs:
+            if 'nodes=1:' not in sched_addl_vars:
+                parser.error("'nodes=1' must be in PBS resource request for --tasks-per-job > 1")
+            sched_addl_vars = sched_addl_vars.replace('nodes=1', 'nodes={}'.format(args.tasks_per_job))
+        if args.slurm:
+            # TODO: Implement --tasks-per-job for SLURM job submission
+            pass
+    else:
+        batch_job_submission = False
 
     ## Set default arguments by project setting
     if args.project is None and True in [arg is None for arg in
@@ -314,8 +336,11 @@ def main():
     if args.chain_mst and args.project is None:
         parser.error('--chain-mst option requires --project arg is also provided')
 
+    log_time = datetime.now().strftime("%Y%m%d%H%M%S")
     bst_logdir = os.path.join(args.logdir, 'matlab', 'bst', target_res)
     pbs_logdir = os.path.join(args.logdir, 'pbs', 'bst', target_res)
+    if batch_job_submission:
+        pbs_logdir = '{}_batch_{}_{}-tiles'.format(pbs_logdir, log_time, len(tiles))
     swift_logrootdir = os.path.join(args.logdir, 'swift')
     swift_logdir = os.path.join(swift_logrootdir, 'bst', target_res)
     swift_tasklist_dir = os.path.join(swift_logrootdir, 'tasklist')
@@ -328,10 +353,16 @@ def main():
         outdir_list.append(pbs_logdir)
     if args.swift:
         outdir_list.extend([swift_rundir, swift_logdir, swift_tasklist_dir])
-    for outdir in outdir_list:
-        if not os.path.isdir(outdir):
-            print("Creating output directory: {}".format(outdir))
-            os.makedirs(outdir)
+    if not args.dryrun:
+        for outdir in outdir_list:
+            if not os.path.isdir(outdir):
+                print("Creating output directory: {}".format(outdir))
+                os.makedirs(outdir)
+        if batch_job_submission:
+            pbs_batch_tilelist = os.path.join(pbs_logdir, 'tilelist.txt')
+            with open(pbs_batch_tilelist, 'w') as tilelist_fp:
+                for tile in tiles:
+                    tilelist_fp.write(tile+'\n')
 
 
     ## Create temp jobscript with mosaicking args filled in
@@ -417,6 +448,7 @@ def main():
             'project': args.project,
             'make_10m_only': make_10m_only,
             'keep_subtiles': str(args.chain_mst_keep_subtiles).lower(),
+            'use_local': str(not args.chain_mst_no_local).lower(),
         }
         if not auto_select_arcticdem_water_tile_dir:
             jobscript_static_args_dict['waterTileDir'] = args.water_tile_dir
@@ -443,11 +475,14 @@ def main():
         with open(jobscript_temp, 'w') as jobscript_fp:
             jobscript_fp.write(jobscript_temp_text)
 
+    tilerun_jobscript = jobscript_temp
+
 
     number_incomplete_tiles = 0
     tiles_to_run = []
     tiles_missing_watermask = []
     tile_waterTileDir_dict = dict()
+    waterTileDir_tilesToRun_dict = dict()
     incomplete_tiles_missing_watermask = []
 
     for tile in tiles:
@@ -593,6 +628,9 @@ def main():
                 incomplete_tiles_missing_watermask.append(tile)
             else:
                 tiles_to_run.append(tile)
+                if water_tile_dir not in waterTileDir_tilesToRun_dict:
+                    waterTileDir_tilesToRun_dict[water_tile_dir] = []
+                waterTileDir_tilesToRun_dict[water_tile_dir].append(tile)
 
 
     if len(tiles_to_run) != number_incomplete_tiles:
@@ -649,55 +687,79 @@ def main():
         print("Ran {} tiles".format(len(tiles_to_run)))
 
     else:
-        for tasknum, tile in enumerate(tiles_to_run, 1):
 
-            job_name = 'bst_{}'.format(tile)
-            job_outfile = os.path.join(pbs_logdir, tile+'.out')
-            job_errfile = os.path.join(pbs_logdir, tile+'.err')
+        jobnum_total = int(math.ceil(len(tiles_to_run) / float(args.tasks_per_job)))
+        jobnum_fmt = '{:0>'+str(min(3, len(str(jobnum_total))))+'}'
 
-            arg_waterTileDir = None
-            if auto_select_arcticdem_water_tile_dir:
-                arg_waterTileDir = tile_waterTileDir_dict[tile]
+        for water_tile_dir, tiles_to_run in waterTileDir_tilesToRun_dict.items():
+            for jobnum, task_start_idx in enumerate(range(0, len(tiles_to_run), args.tasks_per_job), 1):
 
-            if args.pbs:
-                cmd = r""" {}qsub -N {} -v ARG_TILENAME={}{}{} {} {} {} "{}" """.format(
-                    sched_presubmit_cmd+' ; ' if sched_presubmit_cmd != '' else '',
-                    job_name,
-                    tile,
-                    ',ARG_WATERTILEDIR="{}"'.format(arg_waterTileDir) if arg_waterTileDir is not None else '',
-                    ','+sched_addl_envvars if sched_addl_envvars != '' else '',
-                    '-q {}'.format(args.queue) if args.queue is not None else '',
-                    '-o "{}" -e "{}"'.format(job_outfile, job_errfile) if sched_specify_outerr_paths else '',
-                    sched_addl_vars,
-                    jobscript_temp,
-                )
-
-            elif args.slurm:
-                cmd = r""" {}sbatch -J {} -v ARG_TILENAME={}{} {} {} "{}" """.format(
-                    sched_presubmit_cmd+' ; ' if sched_presubmit_cmd != '' else '',
-                    job_name,
-                    tile,
-                    ',ARG_WATERTILEDIR="{}"'.format(arg_waterTileDir) if arg_waterTileDir is not None else '',
-                    ','+sched_addl_envvars if sched_addl_envvars != '' else '',
-                    '-o "{}" -e "{}"'.format(job_outfile, job_errfile) if sched_specify_outerr_paths else '',
-                    sched_addl_vars,
-                    jobscript_temp,
-                )
-
-            else:
-                cmd = r""" {}bash "{}" {} """.format(
-                    'export ARG_WATERTILEDIR="{}"'.format(arg_waterTileDir) if arg_waterTileDir is not None else '',
-                    jobscript_temp,
-                    tile,
-                )
-
-            print("{}, {}".format(tasknum, cmd))
-            if not args.dryrun:
-                matlab_cmd_rc = subprocess.call(cmd, shell=True, cwd=(pbs_logdir if args.pbs else None))
-                if matlab_cmd_rc == 2 and matlab_cmd_success is not False:
-                    matlab_cmd_success = True
+                tile_bundle = tiles_to_run[task_start_idx:task_start_idx+args.tasks_per_job]
+                if batch_job_submission:
+                    tile = None
+                    task_name = jobnum_fmt.format(jobnum)
                 else:
-                    matlab_cmd_success = False
+                    tile = tiles_to_run[task_start_idx]
+                    task_name = tile
+                job_name = 'bst_{}'.format(task_name)
+                job_outfile = os.path.join(pbs_logdir, task_name+'.out')
+                job_errfile = os.path.join(pbs_logdir, task_name+'.err')
+
+                arg_waterTileDir = None
+                if auto_select_arcticdem_water_tile_dir:
+                    arg_waterTileDir = water_tile_dir
+
+                if batch_job_submission and len(tile_bundle) < args.tasks_per_job:
+                    sched_addl_vars_inst = sched_addl_vars.replace(
+                        'nodes={}'.format(args.tasks_per_job),
+                        'nodes={}'.format(len(tile_bundle))
+                    )
+                else:
+                    sched_addl_vars_inst = sched_addl_vars
+
+                if args.pbs:
+                    cmd = r""" {}qsub -N {} -v {}{}ARG_TILENAME={}{}{} {} {} {} "{}" """.format(
+                        sched_presubmit_cmd+' ; ' if sched_presubmit_cmd != '' else '',
+                        job_name,
+                        'TILERUN_JOBSCRIPT="{}",'.format(tilerun_jobscript) if batch_job_submission else '',
+                        'IN_PARALLEL=true,' if batch_job_submission else '',
+                        '@'.join(tile_bundle) if batch_job_submission else tile,
+                        ',ARG_WATERTILEDIR="{}"'.format(arg_waterTileDir) if arg_waterTileDir is not None else '',
+                        ','+sched_addl_envvars if sched_addl_envvars != '' else '',
+                        '-q {}'.format(args.queue) if args.queue is not None else '',
+                        '-o "{}" -e "{}"'.format(job_outfile, job_errfile) if sched_specify_outerr_paths else '',
+                        sched_addl_vars_inst,
+                        batch_jobscript if batch_job_submission else tilerun_jobscript,
+                    )
+
+                elif args.slurm:
+                    cmd = r""" {}sbatch -J {} -v {}{}ARG_TILENAME={}{}{} {} {} "{}" """.format(
+                        sched_presubmit_cmd+' ; ' if sched_presubmit_cmd != '' else '',
+                        job_name,
+                        'TILERUN_JOBSCRIPT="{}",'.format(tilerun_jobscript) if batch_job_submission else '',
+                        'IN_PARALLEL=true,' if batch_job_submission else '',
+                        '@'.join(tile_bundle) if batch_job_submission else tile,
+                        ',ARG_WATERTILEDIR="{}"'.format(arg_waterTileDir) if arg_waterTileDir is not None else '',
+                        ','+sched_addl_envvars if sched_addl_envvars != '' else '',
+                        '-o "{}" -e "{}"'.format(job_outfile, job_errfile) if sched_specify_outerr_paths else '',
+                        sched_addl_vars_inst,
+                        batch_jobscript if batch_job_submission else tilerun_jobscript,
+                    )
+
+                else:
+                    cmd = r""" {}bash "{}" {} """.format(
+                        'export ARG_WATERTILEDIR="{}"'.format(arg_waterTileDir) if arg_waterTileDir is not None else '',
+                        jobscript_temp,
+                        tile,
+                    )
+
+                print("{}, {}".format(jobnum, cmd))
+                if not args.dryrun:
+                    matlab_cmd_rc = subprocess.call(cmd, shell=True, cwd=(pbs_logdir if args.pbs else None))
+                    if matlab_cmd_rc == 2 and matlab_cmd_success is not False:
+                        matlab_cmd_success = True
+                    else:
+                        matlab_cmd_success = False
 
         if args.pbs or args.slurm:
             print("Submitted {} tiles to scheduler".format(number_run_tiles_text))

--- a/batch_mosaicSubTiles.py
+++ b/batch_mosaicSubTiles.py
@@ -537,10 +537,11 @@ def main():
                 job_errfile = os.path.join(pbs_logdir, task_name+'.err')
 
                 if args.pbs:
-                    cmd = r""" {}qsub -N {} -v {}ARG_TILENAME={}{} {} {} {} "{}" """.format(
+                    cmd = r""" {}qsub -N {} -v {}{}ARG_TILENAME={}{} {} {} {} "{}" """.format(
                         sched_presubmit_cmd+' ; ' if sched_presubmit_cmd != '' else '',
                         job_name,
                         'TILERUN_JOBSCRIPT="{}",'.format(tilerun_jobscript) if batch_job_submission else '',
+                        'IN_PARALLEL=false,' if batch_job_submission else '',
                         '@'.join(tile_bundle) if batch_job_submission else tile,
                         ','+sched_addl_envvars if sched_addl_envvars != '' else '',
                         '-q {}'.format(args.queue) if args.queue is not None else '',
@@ -552,10 +553,11 @@ def main():
                 elif args.slurm:
                     job_outfile = job_outfile.replace('pbs', 'slurm')
                     job_errfile = job_errfile.replace('pbs', 'slurm')
-                    cmd = r""" {}sbatch -J {} -v {}ARG_TILENAME={} {} {} "{}" """.format(
+                    cmd = r""" {}sbatch -J {} -v {}{}ARG_TILENAME={} {} {} "{}" """.format(
                         sched_presubmit_cmd+' ; ' if sched_presubmit_cmd != '' else '',
                         job_name,
                         'TILERUN_JOBSCRIPT="{}",'.format(tilerun_jobscript) if batch_job_submission else '',
+                        'IN_PARALLEL=false,' if batch_job_submission else '',
                         '@'.join(tile_bundle) if batch_job_submission else tile,
                         ','+sched_addl_envvars if sched_addl_envvars != '' else '',
                         '-o "{}" -e "{}"'.format(job_outfile, job_errfile) if sched_specify_outerr_paths else '',

--- a/qsub_batchRunTiles.sh
+++ b/qsub_batchRunTiles.sh
@@ -2,12 +2,28 @@
 
 tilelist_string="$ARG_TILENAME"
 tilerun_jobscript="$TILERUN_JOBSCRIPT"
+run_tiles_in_parallel="$IN_PARALLEL"
 
 IFS='@' read -r -a tilelist_arr <<< "$tilelist_string"
 total_ntiles=${#tilelist_arr[@]}
 
+if [ "$run_tiles_in_parallel" = true ]; then
+    echo "Will run ${total_ntiles} tiles in parallel"
+else
+    echo "Will run ${total_ntiles} tiles in serial"
+fi
+
 for tile_idx in "${!tilelist_arr[@]}"; do
     tile="${tilelist_arr[$tile_idx]}"
     echo -e "\n\nRunning tile $((tile_idx+1)) of ${total_ntiles}: ${tile}"
-    bash "$tilerun_jobscript" "$tile"
+    export ARG_TILENAME="$tile"
+    if [ "$run_tiles_in_parallel" = true ]; then
+        bash "$tilerun_jobscript" &
+    else
+        bash "$tilerun_jobscript"
+    fi
 done
+
+if [ "$run_tiles_in_parallel" = true ]; then
+    wait
+fi

--- a/qsub_buildSubTiles.sh
+++ b/qsub_buildSubTiles.sh
@@ -99,17 +99,21 @@ make2m="$ARG_MAKE2M"
 finfile="$ARG_FINFILE"
 logfile="$ARG_LOGFILE"
 runscript="$ARG_RUNSCRIPT"
+set +u; temp_subtile_dir="$TEMP_SUBTILE_DIR"; set -u
 
 if (( $# == 1 )); then
     if [ "$1" = '--make-10m-only' ]; then
         make2m=false
-    elif [ -z "$tileName" ]; then
+    else
         tileName="$1"
     fi
 fi
 if [ -z "$tileName" ]; then
     echo "argument 'tileName' not supplied, exiting"
     exit 0
+fi
+if [ -n "$temp_subtile_dir" ]; then
+    outDir="$temp_subtile_dir"
 fi
 
 utm_tilePrefix=$(echo "$tileName" | grep -Eo '^utm[0-9]{2}[ns]')
@@ -195,7 +199,7 @@ fi
 
 if [ "$MATLAB_USE_PARPOOL" = true ]; then
     job_working_dir="${MATLAB_WORKING_DIR}"
-    job_temp_dir="${MATLAB_TEMP_DIR}/${JOB_ID}"
+    job_temp_dir="${MATLAB_TEMP_DIR}/${JOB_ID}/${tileName}"
     matlab_parpool_init="\
 pc = parcluster('local'); \
 pc.JobStorageLocation = '${job_temp_dir}'; \

--- a/qsub_mosaicSubTiles.sh
+++ b/qsub_mosaicSubTiles.sh
@@ -95,12 +95,13 @@ version="$ARG_VERSION"
 exportTif="$ARG_EXPORTTIF"
 finfile="$ARG_FINFILE"
 logfile="$ARG_LOGFILE"
+set +u; temp_subtile_dir="$TEMP_SUBTILE_DIR"; set -u
 
 if (( $# == 1 )); then
-    if [ -z "$tileName" ]; then
-        tileName="$1"
-    else
+    if [ "$1" = '10' ] || [ "$1" = '2' ]; then
         resolution="$1"
+    else
+        tileName="$1"
     fi
 fi
 if [ -z "$tileName" ]; then
@@ -108,6 +109,9 @@ if [ -z "$tileName" ]; then
     exit 0
 fi
 outTileName="$tileName"
+if [ -n "$temp_subtile_dir" ]; then
+    subTileDir="$temp_subtile_dir"
+fi
 
 utm_tileprefix=$(echo "$tileName" | grep -Eo '^utm[0-9]{2}[ns]')
 if [ -z "$utm_tileprefix" ]; then
@@ -212,7 +216,7 @@ fi
 
 if [ "$MATLAB_USE_PARPOOL" = true ]; then
     job_working_dir="${MATLAB_WORKING_DIR}"
-    job_temp_dir="${MATLAB_TEMP_DIR}/${JOB_ID}"
+    job_temp_dir="${MATLAB_TEMP_DIR}/${JOB_ID}/${tileName}"
     matlab_parpool_init="\
 pc = parcluster('local'); \
 pc.JobStorageLocation = '${job_temp_dir}'; \


### PR DESCRIPTION
- New `--tasks-per-job` option for running multi-node parallel BST(+MST) tile jobs
- Use compute node local space for BST+MST subtiles on BW by default