### PR TITLE
4.0 code adjustments re tile buffer crop & merge

### DIFF
--- a/batchMergeTileBuffer_old.m
+++ b/batchMergeTileBuffer_old.m
@@ -1,0 +1,62 @@
+function batchMergeTileBuffer_old(f)
+% batchMergeTileBuffer: mergeTileBuffer to all neighboring files
+%
+% batchMergeTileBuffer(f) where f is a cellstr of files to be merged.
+
+
+f=f(:);
+
+% loop through each tile and get extents
+x0 = nan(size(f));
+x1= nan(size(f));
+y0= nan(size(f));
+y1= nan(size(f));
+i=1;
+for i=1:length(f)
+    m = matfile(f{i});
+    x0(i)  = min(m.x);
+    x1(i) = max(m.x);
+    y0(i)  = min(m.y);
+    y1(i) = max(m.y);
+end
+    
+% using ranges, find neighbors on each side
+nright= nan(length(f),2);
+ntop= nan(length(f),2);
+i=1;
+for i=1:length(f)
+
+    %right
+    n = find(x0(i) < x0 & x1(i) > x0 & (y0(i)+y1(i))./2 > y0 & (y0(i)+y1(i))./2 < y1);
+    if ~isempty(n)
+        nright(i,:) = [i,n];
+    end
+    
+    %top
+    n = find(y0(i) < y0 & y1(i) > y0 & (x0(i)+x1(i))./2 > x0 & (x0(i)+x1(i))./2 < x1);
+    if ~isempty(n)
+        ntop(i,:) = [i,n];
+    end
+    
+end
+
+n0 = [nright(~isnan(nright(:,1)),1);ntop(~isnan(ntop(:,1)),1)];
+n1 = [nright(~isnan(nright(:,1)),2);ntop(~isnan(ntop(:,1)),2)];
+    
+
+% run mergeTileBuffer on each pair in list
+for i=1:length(n0)
+    try
+        mergeTileBuffer(f{n0(i)},f{n1(i)});
+    catch ME
+%        warning('cant determine side being merged')
+        rethrow(ME)
+    end
+end
+    
+    
+    
+
+
+
+

--- a/cropTile.m
+++ b/cropTile.m
@@ -1,60 +1,71 @@
+function cropTile(tileFile_or_list)
 
-tileFile='/Users/ihowat/data4/REMA/test_2m_tiles/tiles/37_10_1_1_2m.mat';
+%tileFile='/Users/ihowat/data4/REMA/test_2m_tiles/tiles/37_10_1_1_2m.mat';
 
-m = matfile(tileFile);
+if iscell(tileFile_or_list)
+    tileFile_list=tileFile_or_list;
+else
+    tileFile_list={tileFile_or_list};
+end
 
-% number of buffer pixels each side is supposed to have - this is the
-% number of pixels on the outside of edge of the quad tile/subtile
-NPixBuff = 50;
+for tileFile_idx=1:length(tileFile_list)
+    tileFile = tileFile_list{tileFile_idx};
 
-% index of coordinate at the edge of the tile/quadtile boundary
-tileBoundaryIndX = find(mod(m.x,50e3) == 0);
-tileBoundaryIndY = find(mod(m.y,50e3) == 0);
+    m = matfile(tileFile);
 
-%number of buffer pixels on each side
-NPixBuffLeft  = tileBoundaryIndX(1) - 1;
-NPixBuffRight = length(m.x) - tileBoundaryIndX(2);
-NPixBuffTop  = tileBoundaryIndY(1) - 1;
-NPixBuffBot = length(m.y) - tileBoundaryIndY(2);
+    % number of buffer pixels each side is supposed to have - this is the
+    % number of pixels on the outside of edge of the quad tile/subtile
+    NPixBuff = 50;
 
-% check if any buffers are larger than they should be
-if any([NPixBuffLeft NPixBuffRight NPixBuffTop NPixBuffBot] > NPixBuff)
+    % index of coordinate at the edge of the tile/quadtile boundary
+    tileBoundaryIndX = find(mod(m.x,50e3) == 0);
+    tileBoundaryIndY = find(mod(m.y,50e3) == 0);
 
-    % get index ranges of correct buffers
-    IndX = tileBoundaryIndX + [-NPixBuff NPixBuff];
-    IndY = tileBoundaryIndY + [-NPixBuff NPixBuff];
+    %number of buffer pixels on each side
+    NPixBuffLeft  = tileBoundaryIndX(1) - 1;
+    NPixBuffRight = length(m.x) - tileBoundaryIndX(2);
+    NPixBuffTop  = tileBoundaryIndY(1) - 1;
+    NPixBuffBot = length(m.y) - tileBoundaryIndY(2);
 
-    % get list of variables in file
-    flds=fields(m);
+    % check if any buffers are larger than they should be
+    if any([NPixBuffLeft NPixBuffRight NPixBuffTop NPixBuffBot] > NPixBuff)
 
-    % remove Properties (skip) and x and y variables (handled differently)
-    flds(contains(flds,'Properties')) = [];
-    flds(contains(flds,'x')) = [];
-    flds(contains(flds,'y')) = [];
+        % get index ranges of correct buffers
+        IndX = tileBoundaryIndX + [-NPixBuff NPixBuff];
+        IndY = tileBoundaryIndY + [-NPixBuff NPixBuff];
 
-    %  create new matfile
-    m1 = matfile(strrep(tileFile,'.mat','_corrected.mat'));
+        % get list of variables in file
+        flds=fields(m);
 
-    % write cropped x and y vectors
-    m1.x = m.x(1,IndX(1):IndX(2));
-    m1.y = m.y(1,IndY(1):IndY(2));
+        % remove Properties (skip) and x and y variables (handled differently)
+        flds(contains(flds,'Properties')) = [];
+        flds(contains(flds,'x')) = [];
+        flds(contains(flds,'y')) = [];
 
-    % get size of z array for checking variables
-    sz = size(m,'z');
+        %  create new matfile
+        m1 = matfile(strrep(tileFile,'.mat','_corrected.mat'));
 
-    % loop through variables
-    i=1;
-    for i=1:length(flds)
+        % write cropped x and y vectors
+        m1.x = m.x(1,IndX(1):IndX(2));
+        m1.y = m.y(1,IndY(1):IndY(2));
 
-        % check size
-        if all(size(m,flds{i}) == sz)
-            % if same dims as z, write cropped version to new matfile
-            eval(['m1.',flds{i},' = m.',flds{i},...
-                '(IndY(1):IndY(2),IndX(1):IndX(2));'])
-        else
-            % if not same size, just xfer directly
-           eval(['m1.',flds{i},' = m.',flds{i},';'])
+        % get size of z array for checking variables
+        sz = size(m,'z');
+
+        % loop through variables
+        i=1;
+        for i=1:length(flds)
+
+            % check size
+            if all(size(m,flds{i}) == sz)
+                % if same dims as z, write cropped version to new matfile
+                eval(['m1.',flds{i},' = m.',flds{i},...
+                    '(IndY(1):IndY(2),IndX(1):IndX(2));'])
+            else
+                % if not same size, just xfer directly
+               eval(['m1.',flds{i},' = m.',flds{i},';'])
+            end
         end
-    end
 
+    end
 end

--- a/undoMergeTileBuffersSingle.m
+++ b/undoMergeTileBuffersSingle.m
@@ -97,7 +97,7 @@ if ~all(ismember(data_array_names, m_varlist))
 end
 
 % Add data arrays that might be missing from the above list
-z_size = size(m_struct.z);
+z_size = size(m_struct, 'z');
 data_array_names_same_sz = m_varlist(cellfun(@(name) isequal(size(m_struct, name), z_size), m_varlist));
 data_array_names = union(data_array_names, data_array_names_same_sz);
 
@@ -112,11 +112,12 @@ if mergedTop || mergedBottom || mergedLeft || mergedRight
 elseif strcmp(edgeName, 'all')
     fprintf("Tile 'merged{Right&Left&Top&Bottom}=false', indicating tile has not been merged: %s\n", tile_matfile);
     if ignoreMergedVars
-        fprintf(join(["Will attempt to undo merge with possibly existing '*buff' arrays",...
-                      " because 'ignoreMergedVars=true'\n"]), '');
+        fprintf(strjoin(["Will attempt to undo merge with possibly existing '*buff' arrays",...
+                         "because 'ignoreMergedVars=true'\n"]));
     else
-        fprintf(join(["Provide 'ignoreMergedVars=true' if you want to attempt to undo merge with",...
-                      " possibly existing '*buff' arrays\n"]), '');
+        fprintf(strjoin(["Provide 'ignoreMergedVars=true' if you want to attempt to undo merge with",...
+                         "possibly existing '*buff' arrays\n"]));
+        return;
     end
 end
 
@@ -135,11 +136,12 @@ if ~strcmp(edgeName, 'all')
     if indicated_edge_not_merged
         fprintf("Tile 'merged%s=false', indicating tile has not been merged on this edge\n", edgeName);
         if ignoreMergedVars
-            fprintf(join(["Will attempt to undo merge with possibly existing '*buff' arrays",...
-                          " because 'ignoreMergedVars=true'\n"]), '');
+            fprintf(strjoin(["Will attempt to undo merge with possibly existing '*buff' arrays",...
+                             "because 'ignoreMergedVars=true'\n"]));
         else
-            fprintf(join(["Provide 'ignoreMergedVars=true' if you want to attempt to undo merge with",...
-                          " possibly existing '*buff' arrays\n"]), '');
+            fprintf(strjoin(["Provide 'ignoreMergedVars=true' if you want to attempt to undo merge with",...
+                             "possibly existing '*buff' arrays\n"]));
+            return;
         end
     end
 end
@@ -168,7 +170,7 @@ for array_idx = 1:length(reset_array_names)
     data_array_name = reset_array_names{array_idx};     % ex. 'z'
     buff_array_name = [data_array_name,'buff'];         % ex. 'zbuff'
     if ~ismember(buff_array_name, m_varlist)
-        continue
+        continue;
     end
     buff_arrays = getfield(m_struct, buff_array_name);  % four buffer arrays, one for each edge
 
@@ -176,7 +178,7 @@ for array_idx = 1:length(reset_array_names)
         m_struct
         fprintf("Tile '%s' is empty; if '%s' is merged, cannot undo\n", buff_array_name, data_array_name);
         unmerge_failure_general = true;
-        continue
+        continue;
     end
 
     if ~strcmp(edgeName, 'all') && isempty(buff_arrays{edge_n})
@@ -184,7 +186,7 @@ for array_idx = 1:length(reset_array_names)
         fprintf("Tile '%s(%d)' (%s side buffer) is empty; if '%s' is merged, cannot undo\n",...
             buff_array_name, edge_n, edgeName, data_array_name);
         unmerge_failure_general = true;
-        continue
+        continue;
     end
 
     data_array = getfield(m_struct, data_array_name);


### PR DESCRIPTION
Significant changes:
- `mergeTileBuffer.m` now can automatically adjust the size of the region within the tile overlap area that is feathered. If a tile has an all-NaN zone on its border, the feathering region is automatically shrunk to exclude that all-NaN zone, to a hardcoded minimum width (in meters) defined at the top of the script.
- `undoMergeTileBuffersSingle.m` should now be complete and robust.
- `cropTile.m` now works on both 10m and 2m tiles, and should safely undo tile buffer merge on the source tiles before writing out the cropped .mat files.