### PR TITLE
Get tile post-process workflow steps running for REMA v2 mosaic at PGC

### DIFF
--- a/addLandMask2REMATiles.m
+++ b/addLandMask2REMATiles.m
@@ -10,8 +10,8 @@ function addLandMask2REMATiles(tileDir,tileDefFile,varargin)
 % end
 
 
-fileNames=dir([tileDir,'/*_10m.mat']);
-%fileNames=dir([tileDir,'/*/*_10m.mat']);
+%fileNames=dir([tileDir,'/*_10m.mat']);
+fileNames=dir([tileDir,'/*.mat']);
 fileNames = fullfile({fileNames.folder}, {fileNames.name});
 
 tileDefs=load(tileDefFile);

--- a/applyRegistration.m
+++ b/applyRegistration.m
@@ -22,6 +22,7 @@ tileName=S{end}(1:5);
 
 % load demMatFile into a matfile object
 m = matfile(demMatFile);
+m_fields = fields(m);
 
 %find this tile
 if ~isempty(registrationFile)
@@ -110,8 +111,17 @@ else
     m1.tmax = applyRegistration2Var(regData.reg.p,m,C,'gridvar','tmax','subsetSize',5000);
     
     % register land mask to mat file if exists
-    if any(strcmp(fields(m),'land'))
+    if any(strcmp(m_fields,'land'))
         m1.land = applyRegistration2Var(regData.reg.p,m,C,'gridvar','land','subsetSize',5000);
+    end
+
+    % additional fields to transfer over
+    add_fields = {'stripList', 'version'};
+    for i=1:length(add_fields)
+        fld = add_fields{i};
+        if any(strcmp(m_fields,fld))
+            eval(['m1.',fld,' = m.',fld,';']);
+        end
     end
 end
 

--- a/batchMergeTileBuffer.m
+++ b/batchMergeTileBuffer.m
@@ -1,29 +1,112 @@
-function batchMergeTileBuffer(tileNeighborIndexFile)
+function batchMergeTileBuffer(tileNeighborIndexFile, varargin)
 % batchMergeTileBuffer: mergeTileBuffer to all neighboring files
 %
 % batchMergeTileBuffer((tileNeighborIndexFile) where tileNeighborIndexFile 
 % contains the list of fileNames to be merged (fileNames) and the tile
 % neighbor index array nN=[indTop, indBottom, indLeft, indRight], created
-% by tileNeighborIndex 
+% by tileNeighborIndex
+
+tiles=[];
+quad_row=[];
+quad_col=[];
+rows=false;
+cols=false;
+
+if ~isempty(varargin)
+    n = find(strcmpi('tiles', varargin));
+    if ~isempty(n)
+        tiles = varargin{n+1};
+    end
+
+    n = find(strcmpi('quad_row', varargin));
+    if ~isempty(n)
+        quad_row = varargin{n+1};
+    end
+    n = find(strcmpi('quad_col', varargin));
+    if ~isempty(n)
+        quad_col = varargin{n+1};
+    end
+
+    n = find(strcmpi('rows', varargin));
+    if ~isempty(n)
+        rows = true;
+    end
+    n = find(strcmpi('cols', varargin));
+    if ~isempty(n)
+        cols = true;
+    end
+end
 
 load(tileNeighborIndexFile,'fileNames','nN');
 
-% find files where indices of top and right files exist
-indTopExists = find(~isnan(nN(:,1)));
-indRightExists = find(~isnan(nN(:,4)));
+if ~isempty(tiles)
+    tileNames10m = cellfun(@(x) get10mTileName(x), fileNames, 'UniformOutput',false);
+    selected_tiles = zeros(size(fileNames));
+    for i=1:length(tiles)
+        selected_tiles = selected_tiles | strcmp(tileNames10m, tiles{i});
+    end
 
-% concatenate vectors of indices of bottom/top and left/right pairs
-n0 =[indTopExists; indRightExists]; %[bottom file0; left file0] 
-n1 = [nN(indTopExists,1); nN(indRightExists,4)]; %[top file1; right file1]
+    if ~isempty(quad_row) || ~isempty(quad_col)
+        [file_quad_rows, file_quad_cols] = cellfun(@(x) getQuadTileRowCol(x), fileNames, 'UniformOutput',false);
+        file_quad_rows = cell2mat(file_quad_rows);
+        file_quad_cols = cell2mat(file_quad_cols);
+        if ~isempty(quad_row)
+            selected_tiles = selected_tiles & (file_quad_rows == quad_row);
+        end
+        if ~isempty(quad_col)
+            selected_tiles = selected_tiles & (file_quad_cols == quad_col);
+        end
+    end
+else
+    selected_tiles = ones(size(fileNames));
+end
+if ~isequal(size(selected_tiles), size(nN))
+    selected_tiles = selected_tiles.';
+end
+
+% find files where indices of top and right files exist
+indTopExists = find(selected_tiles & ~isnan(nN(:,1)));
+indRightExists = find(selected_tiles & ~isnan(nN(:,4)));
+
+if cols
+    n0 = indTopExists;
+    n1 = nN(indTopExists,1);
+elseif rows
+    n0 = indRightExists;
+    n1 = nN(indRightExists,4);
+else
+    % concatenate vectors of indices of bottom/top and left/right pairs
+    n0 = [indTopExists; indRightExists]; %[bottom file0; left file0]
+    n1 = [nN(indTopExists,1); nN(indRightExists,4)]; %[top file1; right file1]
+end
 
 % run mergeTileBuffer on each pair in list
 for i=1:length(n0)
-    mergeTileBuffer(fileNames{n0(i)},fileNames{n1(i)}); 
+    mergeTileBuffer(fileNames{n0(i)},fileNames{n1(i)});
 end
-    
-    
-    
 
+% If running a subset of tiles, make sure all border tiles
+% have their edges merged to the outside world by checking
+% and running the bottom and left merges if necessary.
+if ~isempty(tiles)
+    % find files where indices of bottom and left files exist
+    indBottomExists = find(selected_tiles & ~isnan(nN(:,2)));
+    indLeftExists = find(selected_tiles & ~isnan(nN(:,3)));
 
+    if cols
+        n0 = indBottomExists;
+        n1 = nN(indBottomExists,2);
+    elseif rows
+        n0 = indLeftExists;
+        n1 = nN(indLeftExists,3);
+    else
+        % concatenate vectors of indices of bottom/top and left/right pairs
+        n0 = [indBottomExists; indLeftExists]; %[top file0; right file0]
+        n1 = [nN(indBottomExists,2); nN(indLeftExists,3)]; %[bottom file1; left file1]
+    end
 
-
+    % run mergeTileBuffer on each pair in list
+    for i=1:length(n0)
+        mergeTileBuffer(fileNames{n0(i)},fileNames{n1(i)});
+    end
+end

--- a/batch_boundaryAdjustApply.m
+++ b/batch_boundaryAdjustApply.m
@@ -2,15 +2,32 @@ function batch_boundaryAdjustApply(tileNeighborIndexFile,varargin)
 
 strt=1;
 inc=1;
+tiles=[];
+quad_row=[];
+quad_col=[];
+
 if ~isempty(varargin)
     n=find(strcmpi(varargin,'start'));
     if ~isempty(n)
         strt=varargin{n+1};
     end
-    
     n=find(strcmpi(varargin,'inc'));
     if ~isempty(n)
         inc=varargin{n+1};
+    end
+
+    n = find(strcmpi('tiles', varargin));
+    if ~isempty(n)
+        tiles = varargin{n+1};
+    end
+
+    n = find(strcmpi('quad_row', varargin));
+    if ~isempty(n)
+        quad_row = varargin{n+1};
+    end
+    n = find(strcmpi('quad_col', varargin));
+    if ~isempty(n)
+        quad_col = varargin{n+1};
     end
 end
 
@@ -25,11 +42,24 @@ end
 %% dz0 calc and write loop - this could be run simultaneously/parallel
 i=strt;
 for i=strt:inc:length(fileNames)
+    if ~isempty(tiles)
+        if ~any(strcmp(get10mTileName(fileNames{i}), tiles))
+            continue
+        end
+    end
+    if ~isempty(quad_row) || ~isempty(quad_col)
+        [qrow, qcol] = getQuadTileRowCol(fileNames{i});
+        if ~isempty(quad_row) && qrow ~= quad_row
+            continue
+        end
+        if ~isempty(quad_col) && qcol ~= quad_col
+            continue
+        end
+    end
+
     fprintf('%d: applying dz0 to %s\n',i,fileNames{i})
     % get this tile name and set is2 file name from it
     boundaryAdjustApply(fileNames{i})
 end
 
 fprintf('complete\n')
-
-    

--- a/batch_boundaryAdjustCalc.m
+++ b/batch_boundaryAdjustCalc.m
@@ -17,16 +17,32 @@ function batch_boundaryAdjustCalc(tileNeighborIndexFile,varargin)
 %resizeFraction=0.1;
 strt=1;
 inc=1;
+tiles=[];
+quad_row=[];
+quad_col=[];
 
 if ~isempty(varargin)
     n=find(strcmpi(varargin,'start'));
     if ~isempty(n)
         strt=varargin{n+1};
     end
-    
     n=find(strcmpi(varargin,'inc'));
     if ~isempty(n)
         inc=varargin{n+1};
+    end
+
+    n = find(strcmpi('tiles', varargin));
+    if ~isempty(n)
+        tiles = varargin{n+1};
+    end
+
+    n = find(strcmpi('quad_row', varargin));
+    if ~isempty(n)
+        quad_row = varargin{n+1};
+    end
+    n = find(strcmpi('quad_col', varargin));
+    if ~isempty(n)
+        quad_col = varargin{n+1};
     end
 end
 
@@ -41,6 +57,21 @@ end
 %% dz0 calc and write loop - this could be run simultaneously/parallel
 i=strt;
 for i=strt:inc:length(fileNames)
+    if ~isempty(tiles)
+        if ~any(strcmp(get10mTileName(fileNames{i}), tiles))
+            continue
+        end
+    end
+    if ~isempty(quad_row) || ~isempty(quad_col)
+        [qrow, qcol] = getQuadTileRowCol(fileNames{i});
+        if ~isempty(quad_row) && qrow ~= quad_row
+            continue
+        end
+        if ~isempty(quad_col) && qcol ~= quad_col
+            continue
+        end
+    end
+
     fprintf('%d: Calculating offset grid for %s .... ',i,fileNames{i})
     
     if ~any(~isnan(nN(i,:)))

--- a/batch_tiles2tif_v4.m
+++ b/batch_tiles2tif_v4.m
@@ -1,0 +1,61 @@
+function batch_tiles2tif(tileDir,projstr,varargin)
+
+%% Parse optional args
+
+% Arg default values
+resolution = '10m';
+metaOnly = false;
+
+if ~isempty(varargin)
+    n = find(strcmpi('resolution', varargin));
+    if ~isempty(n)
+        resolution = varargin{n+1};
+    end
+
+    n = find(strcmpi('metaOnly', varargin));
+    if ~isempty(n)
+        metaOnly = true;
+    end
+end
+
+%% Verify args
+
+if ~isfolder(tileDir)
+    error("input 'tileDir' folder does not exist: %s", tileDir);
+end
+
+resolution_choices = {'10m', '2m'};
+if ~ismember(resolution, resolution_choices)
+    error("'resolution' must be one of the following, but was '%s': {'%s'}", resolution, strjoin(resolution_choices, "', '"));
+end
+
+
+%% Gather input tiles to process
+
+unregFiles=dir([tileDir,'/*_',resolution,'.mat']);
+unregFiles=fullfile({unregFiles.folder}, {unregFiles.name});
+
+if ~isempty(unregFiles)
+    regFiles = strrep(unregFiles, [resolution,'.mat'], [resolution,'_reg.mat']);
+
+    n = cellfun(@exist, regFiles);
+    n = n==2;
+
+    fileNames = [regFiles(n) unregFiles(~n)];
+else
+    fileNames=dir([tileDir,'/*_',resolution,'_reg.mat']);
+    fileNames=fullfile({fileNames.folder}, {fileNames.name});
+end
+
+
+%% Main processing loop
+
+num_tiles = length(fileNames);
+for tile_idx = 1:num_tiles
+    tile_file = fileNames{tile_idx};
+    fprintf("\nProcessing tile (%d/%d): %s\n\n", tile_idx, num_tiles, tile_file);
+    if ~metaOnly
+        writeTileToTifv4(tile_file, projstr, varargin(:));
+    end
+    tileMetav4(tile_file, varargin(:));
+end

--- a/boundaryAdjustCalc.m
+++ b/boundaryAdjustCalc.m
@@ -7,14 +7,17 @@ function boundaryAdjustCalc(fileName,neighborFiles,varargin)
 % left, right, top-left, top-right, bottom-left, bottom-right, with empty
 % cells indicating no file.
 
-resizeFraction=0.1;
+m0=matfile(fileName);
+
+% standard resizeFraction is for 10m, scale for 2m and other res
+resizeFraction_10m = 0.1;
+res = m0.x(1,2) - m0.x(1,1);
+resizeFraction = min(1.0, resizeFraction_10m * (res/10));
 
 n=find(strcmpi(varargin,'resizeFraction'));
 if ~isempty(n)
     resizeFraction=varargin{n+1};
 end
-
-m0=matfile(fileName);
 
 if any(strcmpi(fields(m0),'adjusted')) 
     if m0.adjusted == 1

--- a/boundaryAdjustCalc.m
+++ b/boundaryAdjustCalc.m
@@ -239,7 +239,7 @@ r1 = [find(r1,1,'first'),find(r1,1,'last')];
 
 dz1 = zeros(length(r1(1):r1(2)),length(c1(1):c1(2)));
 if any(strcmpi(fields(m1),'adjusted'))
-    if m0.adjusted == 1
+    if m1.adjusted == 1
         dz1=imresize(m1.dz0,size(m1,'z'));
         dz1=dz1(r1(1):r1(2),c1(1):c1(2));
     end

--- a/boundaryAdjustCalc.m
+++ b/boundaryAdjustCalc.m
@@ -18,7 +18,7 @@ m0=matfile(fileName);
 
 if any(strcmpi(fields(m0),'adjusted')) 
     if m0.adjusted == 1
-        fprintf('adjustment applied,undo adjustment before calculating new, skipping')
+        fprintf('adjustment applied, undo adjustment before calculating new, skipping, ')
         return
     end
 end

--- a/cropTile.m
+++ b/cropTile.m
@@ -16,7 +16,7 @@ for tileFile_idx=1:length(tileFile_list)
     end
     tileFile_cropped = strrep(tileFile, '.mat', '_cropped.mat');
 
-    fprintf("Working on tile file: %s\n", tileFile);
+    fprintf("\nWorking on tile file: %s\n", tileFile);
     if isfile(tileFile_cropped)
         fprintf("Cropped tile already exists, skipping: %s\n", tileFile_cropped);
         continue;

--- a/cropTile.m
+++ b/cropTile.m
@@ -120,6 +120,10 @@ for tileFile_idx=1:length(tileFile_list)
         fprintf("Writing cropped tile file: %s\n", tileFile_cropped);
         m1 = matfile(tileFile_cropped);
 
+        m1.cropped = true;
+        m1.precrop_x = m.x;
+        m1.precrop_y = m.y;
+
         % write cropped x and y vectors
         m1.x = m.x(1,IndX(1):IndX(2));
         m1.y = m.y(1,IndY(1):IndY(2));

--- a/findNeighborTiles.m
+++ b/findNeighborTiles.m
@@ -10,6 +10,9 @@ function [ntop,nright,ntopRight,nbottomRight] = findNeighborTiles(fileNames)
 
 fileNames=fileNames(:);
 
+% capture UTM mosaic zone prefix to keep zones separate
+utmzone = cellfun(@(x) getTileNamePrefix(x), fileNames, 'UniformOutput',false);
+
 % loop through each tile and get extents
 x0 = nan(size(fileNames));
 x1= nan(size(fileNames));
@@ -40,25 +43,25 @@ fprintf('looping through ranges to find neighbors\n')
 i=1;
 for i=1:length(fileNames)
     %top
-    n = find(y0(i) < y0 & y1(i) >= y0 & mnx(i) > x0 & mnx(i) < x1);
+    n = find(strcmp(utmzone{i}, utmzone) & y0(i) < y0 & y1(i) >= y0 & mnx(i) > x0 & mnx(i) < x1);
     if ~isempty(n)
         ntop(i,:) = [i,n];
     end
 
     %right
-    n = find(x0(i) < x0 & x1(i) >= x0 & mny(i) > y0 & mny(i) < y1);
+    n = find(strcmp(utmzone{i}, utmzone) & x0(i) < x0 & x1(i) >= x0 & mny(i) > y0 & mny(i) < y1);
     if ~isempty(n)
         nright(i,:) = [i,n];
     end
     
     %top-right
-    n = find(y0(i) < y0 & y1(i) >= y0 & x0(i) < x0 & x1(i) >= x0 & mnx > x1(i) & mny > y1(i));
+    n = find(strcmp(utmzone{i}, utmzone) & y0(i) < y0 & y1(i) >= y0 & x0(i) < x0 & x1(i) >= x0 & mnx > x1(i) & mny > y1(i));
     if ~isempty(n)
         ntopRight(i,:) = [i,n];
     end
 
     %bottom-right
-    n = find(y0(i) > y0 & y0(i) <= y1 & x0(i) < x0 & x1(i) >= x0 & mnx > x1(i) & mny < y0(i));
+    n = find(strcmp(utmzone{i}, utmzone) & y0(i) > y0 & y0(i) <= y1 & x0(i) < x0 & x1(i) >= x0 & mnx > x1(i) & mny < y0(i));
     if ~isempty(n)
         nbottomRight(i,:) = [i,n];
     end  
@@ -68,5 +71,3 @@ ntop(isnan(ntop(:,1)),:) = [];
 nright(isnan(nright(:,1)),:) = [];
 ntopRight(isnan(ntopRight(:,1)),:) = [];
 nbottomRight(isnan(nbottomRight(:,1)),:) = [];
-
-

--- a/get10mTileName.m
+++ b/get10mTileName.m
@@ -1,0 +1,3 @@
+function supername = get10mTileName(tileFileName)
+[tileFileDir, tileFileName_noext, tileFileExt] = fileparts(tileFileName);
+[parsed_tilename, supername, quadname, suffix] = parseTileNameWithSuffix(tileFileName_noext);

--- a/getQuadTileRowCol.m
+++ b/getQuadTileRowCol.m
@@ -1,0 +1,3 @@
+function [quad_row, quad_col] = getQuadTileRowCol(tileFileName)
+[tileFileDir, tileFileName_noext, tileFileExt] = fileparts(tileFileName);
+[prefix, super_row, super_col, quad_row, quad_col, suffix] = parseTileNameAll(tileFileName_noext, true);

--- a/getTileNamePrefix.m
+++ b/getTileNamePrefix.m
@@ -1,0 +1,6 @@
+function prefix = getTileNamePrefix(tileFileFull)
+[tileFileDir, tileFileName_noext, tileFileExt] = fileparts(tileFileFull);
+[prefix, supertile, quadtile, suffix] = parseTileNameParts(tileFileName_noext, true);
+if isempty(prefix)
+    prefix = 'none';
+end

--- a/mergeTileBuffer.m
+++ b/mergeTileBuffer.m
@@ -196,6 +196,8 @@ end
 
 fprintf('merging tiles...\n')
 
+W0_feather_zone = (W0 > 0) & (W0 < 1);
+
 %% merge z
 if ~any(strcmp(varlist0,'zbuff'))
 	m0.zbuff = cell(4,1);
@@ -225,9 +227,9 @@ end
 
 z=(z0.*W0)+(z1.*(1-W0));
 
-n=isnan(z0) & ~isnan(z1);
+n=isnan(z0) & ~isnan(z1) & ~W0_feather_zone;
 z(n)=z1(n);
-n=~isnan(z0) & isnan(z1);
+n=~isnan(z0) & isnan(z1) & ~W0_feather_zone;
 z(n)=z0(n);
 
 m0.z(r0(1):r0(2),c0(1):c0(2))=z;
@@ -271,9 +273,9 @@ end
 
 z_mad=(z_mad0.*W0)+(z_mad1.*(1-W0));
 
-n=isnan(z_mad0) & ~isnan(z_mad1);
+n=isnan(z_mad0) & ~isnan(z_mad1) & ~W0_feather_zone;
 z_mad(n)=z_mad1(n);
-n=~isnan(z_mad0) & isnan(z_mad1);
+n=~isnan(z_mad0) & isnan(z_mad1) & ~W0_feather_zone;
 z_mad(n)=z_mad0(n);
 
 m0.z_mad(r0(1):r0(2),c0(1):c0(2))=z_mad;
@@ -310,9 +312,9 @@ N1=single(N1);
 
 N=(N0.*W0)+(N1.*(1-W0));
 
-n= N0 == 0 & N1 ~= 0;
+n= N0 == 0 & N1 ~= 0 & ~W0_feather_zone;
 N(n)=N1(n);
-n= N0 ~= 0 & N1 == 0;
+n= N0 ~= 0 & N1 == 0 & ~W0_feather_zone;
 N(n)=N0(n);
 
 N=uint8(N);
@@ -351,9 +353,9 @@ Nmt1=single(Nmt1);
 
 Nmt=(Nmt0.*W0)+(Nmt1.*(1-W0));
 
-n= Nmt0 == 0 & Nmt1 ~= 0;
+n= Nmt0 == 0 & Nmt1 ~= 0 & ~W0_feather_zone;
 Nmt(n)=Nmt1(n);
-n= Nmt0 ~= 0 & Nmt1 == 0;
+n= Nmt0 ~= 0 & Nmt1 == 0 & ~W0_feather_zone;
 Nmt(n)=Nmt0(n);
 
 Nmt=uint8(Nmt);
@@ -392,9 +394,9 @@ tmin1=single(tmin1);
 
 tmin=(tmin0.*W0)+(tmin1.*(1-W0));
 
-n= tmin0 == 0 & tmin1 ~= 0;
+n= tmin0 == 0 & tmin1 ~= 0 & ~W0_feather_zone;
 tmin(n)=tmin1(n);
-n= tmin0 ~= 0 & tmin1 == 0;
+n= tmin0 ~= 0 & tmin1 == 0 & ~W0_feather_zone;
 tmin(n)=tmin0(n);
 
 tmin=uint16(tmin);
@@ -433,9 +435,9 @@ tmax1=single(tmax1);
 
 tmax=(tmax0.*W0)+(tmax1.*(1-W0));
 
-n= tmax0 == 0 & tmax1 ~= 0;
+n= tmax0 == 0 & tmax1 ~= 0 & ~W0_feather_zone;
 tmax(n)=tmax1(n);
-n= tmax0 ~= 0 & tmax1 == 0;
+n= tmax0 ~= 0 & tmax1 == 0 & ~W0_feather_zone;
 tmax(n)=tmax0(n);
 
 tmax=uint16(tmax);

--- a/mergeTileBuffer.m
+++ b/mergeTileBuffer.m
@@ -266,6 +266,8 @@ n=isnan(z0) & ~isnan(z1) & ~W0_feather_zone;
 z(n)=z1(n);
 n=~isnan(z0) & isnan(z1) & ~W0_feather_zone;
 z(n)=z0(n);
+n=(isnan(z0) | isnan(z1)) & W0_feather_zone;
+z(n)=nan;
 
 m0.z(r0(1):r0(2),c0(1):c0(2))=z;
 m1.z(r1(1):r1(2),c1(1):c1(2))=z;
@@ -329,6 +331,8 @@ n=isnan(z_mad0) & ~isnan(z_mad1) & ~W0_feather_zone;
 z_mad(n)=z_mad1(n);
 n=~isnan(z_mad0) & isnan(z_mad1) & ~W0_feather_zone;
 z_mad(n)=z_mad0(n);
+n=(isnan(z_mad0) | isnan(z_mad1)) & W0_feather_zone;
+z_mad(n)=nan;
 
 m0.z_mad(r0(1):r0(2),c0(1):c0(2))=z_mad;
 m1.z_mad(r1(1):r1(2),c1(1):c1(2))=z_mad;
@@ -385,6 +389,8 @@ n= N0 == 0 & N1 ~= 0 & ~W0_feather_zone;
 N(n)=N1(n);
 n= N0 ~= 0 & N1 == 0 & ~W0_feather_zone;
 N(n)=N0(n);
+n= (N0 == 0 | N1 == 0) & W0_feather_zone;
+N(n)=0;
 
 N=uint8(N);
 
@@ -443,6 +449,8 @@ n= Nmt0 == 0 & Nmt1 ~= 0 & ~W0_feather_zone;
 Nmt(n)=Nmt1(n);
 n= Nmt0 ~= 0 & Nmt1 == 0 & ~W0_feather_zone;
 Nmt(n)=Nmt0(n);
+n= (Nmt0 == 0 | Nmt1 == 0) & W0_feather_zone;
+Nmt(n)=0;
 
 Nmt=uint8(Nmt);
 
@@ -501,6 +509,8 @@ n= tmin0 == 0 & tmin1 ~= 0 & ~W0_feather_zone;
 tmin(n)=tmin1(n);
 n= tmin0 ~= 0 & tmin1 == 0 & ~W0_feather_zone;
 tmin(n)=tmin0(n);
+n= (tmin0 == 0 | tmin1 == 0) & W0_feather_zone;
+tmin(n)=0;
 
 tmin=uint16(tmin);
 
@@ -559,6 +569,8 @@ n= tmax0 == 0 & tmax1 ~= 0 & ~W0_feather_zone;
 tmax(n)=tmax1(n);
 n= tmax0 ~= 0 & tmax1 == 0 & ~W0_feather_zone;
 tmax(n)=tmax0(n);
+n= (tmax0 == 0 | tmax1 == 0) & W0_feather_zone;
+tmax(n)=0;
 
 tmax=uint16(tmax);
 

--- a/parseTileName.m
+++ b/parseTileName.m
@@ -7,7 +7,7 @@ supertile = [];
 quadtile = [];
 suffix = [];
 
-tilename_re = '(?<prefix>utm\d{2}[ns]_)?(?<supertile>\d{2}_\d{2})(?<quadtile>_\d_\d)?';
+tilename_re = '(?<prefix>utm\d{2}[ns]_)?(?<supertile>\d{2}_\d{2}s?)(?<quadtile>_\d_\d)?';
 if allow_suffix
     tilename_re = ['^', tilename_re, '(?<suffix>.*$)'];
 else

--- a/parseTileName.m
+++ b/parseTileName.m
@@ -1,0 +1,45 @@
+function [parsed_tilename, supername, quadname] = parseTileName(tilename)
+
+allow_suffix = false;
+
+prefix = [];
+supertile = [];
+quadtile = [];
+suffix = [];
+
+tilename_re = '(?<prefix>utm\d{2}[ns]_)?(?<supertile>\d{2}_\d{2})(?<quadtile>_\d_\d)?';
+if allow_suffix
+    tilename_re = ['^', tilename_re, '(?<suffix>.*$)'];
+else
+    tilename_re = ['^', tilename_re, '$'];
+end
+
+[tokens, match_idx] = regexp(tilename, tilename_re, 'names');
+if isempty(match_idx)
+    error("Cannot parse tilename parts with regex '%s' from input tilename string: %s", tilename_re, tilename);
+end
+
+if isfield(tokens, 'prefix') && ~isempty(tokens.prefix)
+    prefix = strip(tokens.prefix, 'right', '_');
+end
+if isfield(tokens, 'supertile') && ~isempty(tokens.supertile)
+    supertile = tokens.supertile;
+end
+if isfield(tokens, 'quadtile') && ~isempty(tokens.quadtile)
+    quadtile = strip(tokens.quadtile, 'left', '_');
+end
+if isfield(tokens, 'suffix') && ~isempty(tokens.suffix)
+    suffix = tokens.suffix;
+end
+
+tilename_parts = {prefix, supertile, quadtile};
+tilename_parts(cellfun(@(s) isempty(s), tilename_parts)) = [];
+parsed_tilename = strjoin(tilename_parts, '_');
+
+supername_parts = {prefix, supertile};
+supername_parts(cellfun(@(s) isempty(s), supername_parts)) = [];
+supername = strjoin(supername_parts, '_');
+
+quadname_parts = {prefix, supertile, quadtile};
+quadname_parts(cellfun(@(s) isempty(s), quadname_parts)) = [];
+quadname = strjoin(quadname_parts, '_');

--- a/parseTileNameAll.m
+++ b/parseTileNameAll.m
@@ -7,7 +7,7 @@ quad_row = [];
 quad_col = [];
 suffix = [];
 
-tilename_re = '(?<prefix>utm\d{2}[ns]_)?(?<supertile>\d{2}_\d{2})(?<quadtile>_\d_\d)?';
+tilename_re = '(?<prefix>utm\d{2}[ns]_)?(?<supertile>\d{2}_\d{2}s?)(?<quadtile>_\d_\d)?';
 if allow_suffix
     tilename_re = ['^', tilename_re, '(?<suffix>.*$)'];
 else
@@ -25,8 +25,8 @@ end
 if isfield(tokens, 'supertile') && ~isempty(tokens.supertile)
     supertile = tokens.supertile;
     parts = split(supertile, '_');
-    super_row = str2double(parts{1});
-    super_col = str2double(parts{2});
+    super_row = parts{1};
+    super_col = parts{2};
 end
 if isfield(tokens, 'quadtile') && ~isempty(tokens.quadtile)
     quadtile = strip(tokens.quadtile, 'left', '_');

--- a/parseTileNameAll.m
+++ b/parseTileNameAll.m
@@ -1,0 +1,39 @@
+function [prefix, super_row, super_col, quad_row, quad_col, suffix] = parseTileNameAll(tilename, allow_suffix)
+
+prefix = [];
+super_row = [];
+super_col = [];
+quad_row = [];
+quad_col = [];
+suffix = [];
+
+tilename_re = '(?<prefix>utm\d{2}[ns]_)?(?<supertile>\d{2}_\d{2})(?<quadtile>_\d_\d)?';
+if allow_suffix
+    tilename_re = ['^', tilename_re, '(?<suffix>.*$)'];
+else
+    tilename_re = ['^', tilename_re, '$'];
+end
+
+[tokens, match_idx] = regexp(tilename, tilename_re, 'names');
+if isempty(match_idx)
+    error("Cannot parse tilename parts with regex '%s' from input tilename string: %s", tilename_re, tilename);
+end
+
+if isfield(tokens, 'prefix') && ~isempty(tokens.prefix)
+    prefix = strip(tokens.prefix, 'right', '_');
+end
+if isfield(tokens, 'supertile') && ~isempty(tokens.supertile)
+    supertile = tokens.supertile;
+    parts = split(supertile, '_');
+    super_row = str2double(parts{1});
+    super_col = str2double(parts{2});
+end
+if isfield(tokens, 'quadtile') && ~isempty(tokens.quadtile)
+    quadtile = strip(tokens.quadtile, 'left', '_');
+    parts = split(quadtile, '_');
+    quad_row = str2double(parts{1});
+    quad_col = str2double(parts{2});
+end
+if isfield(tokens, 'suffix') && ~isempty(tokens.suffix)
+    suffix = tokens.suffix;
+end

--- a/parseTileNameParts.m
+++ b/parseTileNameParts.m
@@ -1,0 +1,31 @@
+function [prefix, supertile, quadtile, suffix] = parseTileNameParts(tilename, allow_suffix)
+
+prefix = [];
+supertile = [];
+quadtile = [];
+suffix = [];
+
+tilename_re = '(?<prefix>utm\d{2}[ns]_)?(?<supertile>\d{2}_\d{2})(?<quadtile>_\d_\d)?';
+if allow_suffix
+    tilename_re = ['^', tilename_re, '(?<suffix>.*$)'];
+else
+    tilename_re = ['^', tilename_re, '$'];
+end
+
+[tokens, match_idx] = regexp(tilename, tilename_re, 'names');
+if isempty(match_idx)
+    error("Cannot parse tilename parts with regex '%s' from input tilename string: %s", tilename_re, tilename);
+end
+
+if isfield(tokens, 'prefix') && ~isempty(tokens.prefix)
+    prefix = strip(tokens.prefix, 'right', '_');
+end
+if isfield(tokens, 'supertile') && ~isempty(tokens.supertile)
+    supertile = tokens.supertile;
+end
+if isfield(tokens, 'quadtile') && ~isempty(tokens.quadtile)
+    quadtile = strip(tokens.quadtile, 'left', '_');
+end
+if isfield(tokens, 'suffix') && ~isempty(tokens.suffix)
+    suffix = tokens.suffix;
+end

--- a/parseTileNameParts.m
+++ b/parseTileNameParts.m
@@ -5,7 +5,7 @@ supertile = [];
 quadtile = [];
 suffix = [];
 
-tilename_re = '(?<prefix>utm\d{2}[ns]_)?(?<supertile>\d{2}_\d{2})(?<quadtile>_\d_\d)?';
+tilename_re = '(?<prefix>utm\d{2}[ns]_)?(?<supertile>\d{2}_\d{2}s?)(?<quadtile>_\d_\d)?';
 if allow_suffix
     tilename_re = ['^', tilename_re, '(?<suffix>.*$)'];
 else

--- a/parseTileNameWithSuffix.m
+++ b/parseTileNameWithSuffix.m
@@ -7,7 +7,7 @@ supertile = [];
 quadtile = [];
 suffix = [];
 
-tilename_re = '(?<prefix>utm\d{2}[ns]_)?(?<supertile>\d{2}_\d{2})(?<quadtile>_\d_\d)?';
+tilename_re = '(?<prefix>utm\d{2}[ns]_)?(?<supertile>\d{2}_\d{2}s?)(?<quadtile>_\d_\d)?';
 if allow_suffix
     tilename_re = ['^', tilename_re, '(?<suffix>.*$)'];
 else

--- a/parseTileNameWithSuffix.m
+++ b/parseTileNameWithSuffix.m
@@ -1,0 +1,45 @@
+function [parsed_tilename, supername, quadname, suffix] = parseTileNameWithSuffix(tilename)
+
+allow_suffix = true;
+
+prefix = [];
+supertile = [];
+quadtile = [];
+suffix = [];
+
+tilename_re = '(?<prefix>utm\d{2}[ns]_)?(?<supertile>\d{2}_\d{2})(?<quadtile>_\d_\d)?';
+if allow_suffix
+    tilename_re = ['^', tilename_re, '(?<suffix>.*$)'];
+else
+    tilename_re = ['^', tilename_re, '$'];
+end
+
+[tokens, match_idx] = regexp(tilename, tilename_re, 'names');
+if isempty(match_idx)
+    error("Cannot parse tilename parts with regex '%s' from input tilename string: %s", tilename_re, tilename);
+end
+
+if isfield(tokens, 'prefix') && ~isempty(tokens.prefix)
+    prefix = strip(tokens.prefix, 'right', '_');
+end
+if isfield(tokens, 'supertile') && ~isempty(tokens.supertile)
+    supertile = tokens.supertile;
+end
+if isfield(tokens, 'quadtile') && ~isempty(tokens.quadtile)
+    quadtile = strip(tokens.quadtile, 'left', '_');
+end
+if isfield(tokens, 'suffix') && ~isempty(tokens.suffix)
+    suffix = tokens.suffix;
+end
+
+tilename_parts = {prefix, supertile, quadtile};
+tilename_parts(cellfun(@(s) isempty(s), tilename_parts)) = [];
+parsed_tilename = strjoin(tilename_parts, '_');
+
+supername_parts = {prefix, supertile};
+supername_parts(cellfun(@(s) isempty(s), supername_parts)) = [];
+supername = strjoin(supername_parts, '_');
+
+quadname_parts = {prefix, supertile, quadtile};
+quadname_parts(cellfun(@(s) isempty(s), quadname_parts)) = [];
+quadname = strjoin(quadname_parts, '_');

--- a/registerTileToIS2.m
+++ b/registerTileToIS2.m
@@ -3,6 +3,18 @@ function registerTileToIS2(tileFile,is2TileFile)
 
 m=matfile(tileFile);
 
+% standard resizeFraction is for 10m, scale for 2m and other res
+resizeFraction_10m = 1.0;
+res = m.x(1,2) - m.x(1,1);
+resizeFraction = min(1.0, resizeFraction_10m * (res/10));
+
+% Erik decided to disable the automatic downsample capability for the
+% 2022 REMAv2 mosaic production after a brief analysis showed that
+% downsampling the 2m during registration resulted in an inconsitent shift
+% between the 10m and 2m versions of mosaic tiles.
+resizeFraction = 1.0;
+
+
 if any(strcmp(fields(m),'reg'))
     fprintf('reg already exists, skipping\n')
     clear m
@@ -21,10 +33,16 @@ is2=load(is2TileFile,'x','y','z','t');
 try
     %load DEM
     load(tileFile,'x','y','z','land');
-    
 catch
     warning('cant read %s\n',tileFile)
     return
+end
+
+if resizeFraction ~= 1.0
+    x = imresize(x, resizeFraction);
+    y = imresize(y, resizeFraction);
+    z = imresize(z, resizeFraction);
+    land = imresize(land, resizeFraction, 'nearest');
 end
 
 if any(~land(:))

--- a/selectTilesForMerging.m
+++ b/selectTilesForMerging.m
@@ -1,30 +1,55 @@
-function fileNames= selectTilesForMerging(tileDir,varargin)
+function fileNames = selectTilesForMerging(tileDir,varargin)
 
 %tileDir='/Users/ihowat/project/howat.4/rema_mosaic/rema_mosaic_v13e';
 
-n = find(strcmpi('resolution',varargin));
-if ~isempty(n)
-    resolution = varargin{n+1};
-else
-    resolution = '10m';
+if ~isfolder(tileDir)
+    error("input 'tileDir' folder does not exist: %s", tileDir);
 end
 
-unregFiles=dir([tileDir,'/*_',resolution,'.mat']);
-%unregFiles=dir([tileDir,'/*/*_',resolution,'.mat']);
+org = 'osu';
+resolution = '10m';
+
+if ~isempty(varargin)
+    org_choices = {'osu', 'pgc'};
+    n = find(strcmpi('org', varargin));
+    if ~isempty(n)
+        org = varargin{n+1};
+    end
+    if ~ismember(org, org_choices)
+        error("'org' must be one of the following, but was '%s': {'%s'}", org, strjoin(org_choices, "', '"));
+    end
+
+    resolution_choices = {'10m', '2m'};
+    n = find(strcmpi('resolution', varargin));
+    if ~isempty(n)
+        resolution = varargin{n+1};
+    end
+    if ~ismember(resolution, resolution_choices)
+        error("'resolution' must be one of the following, but was '%s': {'%s'}", resolution, strjoin(resolution_choices, "', '"));
+    end
+end
+
+if strcmp(org, 'osu')
+    unregFiles=dir([tileDir,'/*_',resolution,'.mat']);
+else
+    unregFiles=dir([tileDir,'/*/*_',resolution,'.mat']);
+end
 unregFiles=fullfile({unregFiles.folder}, {unregFiles.name});
 
 if ~isempty(unregFiles)
     
-    regFiles = strrep(unregFiles,'10m.mat','10m_reg.mat');
+    regFiles = strrep(unregFiles, [resolution,'.mat'], [resolution,'_reg.mat']);
     
-    n = cellfun( @exist, regFiles);
+    n = cellfun(@exist, regFiles);
     n = n==2;
     
     fileNames = [regFiles(n) unregFiles(~n)];
     
 else
-    fileNames=dir([tileDir,'/*_',resolution,'_reg.mat']);
-%    fileNames=dir([tileDir,'/*/*_',resolution,'_reg.mat']);
+    if strcmp(org, 'osu')
+        fileNames=dir([tileDir,'/*_',resolution,'_reg.mat']);
+    else
+        fileNames=dir([tileDir,'/*/*_',resolution,'_reg.mat']);
+    end
     fileNames=fullfile({fileNames.folder}, {fileNames.name});
 end
-

--- a/tileMetav4.m
+++ b/tileMetav4.m
@@ -6,6 +6,7 @@ function tileMetav4(f,varargin)
 
 project='Unspecified';
 tileVersion='Unspecified';
+overwrite=false;
 
 % Parse varargins
 n = find(strcmpi(varargin,'project'));
@@ -18,6 +19,12 @@ n = find(strcmpi(varargin,'tileVersion'));
 if ~isempty(n)
     tileVersion = varargin{n+1};
     fprintf('tileVersion = %s\n',tileVersion)
+end
+
+n = find(strcmpi(varargin,'overwrite'));
+if ~isempty(n)
+    overwrite = true;
+    fprintf('overwrite = %s\n',overwrite)
 end
 
 %% first test if input arg is either a valid filename or mat file handle
@@ -45,7 +52,7 @@ varlist = who(m);
 fileAtts= dir(m.Properties.Source);
 
 % test if exists, skip if does
-if exist(outfile,'file') 
+if exist(outfile,'file') && ~overwrite
     fprintf('%s exists, skipping\n',outfile);
     return;
 end

--- a/tileNeighborIndex.m
+++ b/tileNeighborIndex.m
@@ -1,15 +1,48 @@
 function tileNeighborIndexFile=tileNeighborIndex(tileDir,varargin)
 
-n = find(strcmpi('resolution',varargin));
-if ~isempty(n)
-    resolution = varargin{n+1};
-    use_res_in_outname = true;
-else
-    resolution = '10m';
-    use_res_in_outname = false;
+if ~isfolder(tileDir)
+    error("input 'tileDir' folder does not exist: %s", tileDir);
 end
 
-fileNames = selectTilesForMerging(tileDir,'resolution',resolution);
+org = 'osu';
+resolution = '10m';
+outfile = [];
+
+if ~isempty(varargin)
+    org_choices = {'osu', 'pgc'};
+    n = find(strcmpi('org', varargin));
+    if ~isempty(n)
+        org = varargin{n+1};
+    end
+    if ~ismember(org, org_choices)
+        error("'org' must be one of the following, but was '%s': {'%s'}", org, strjoin(org_choices, "', '"));
+    end
+
+    resolution_choices = {'10m', '2m'};
+    n = find(strcmpi('resolution', varargin));
+    if ~isempty(n)
+        resolution = varargin{n+1};
+    end
+    if ~ismember(resolution, resolution_choices)
+        error("'resolution' must be one of the following, but was '%s': {'%s'}", resolution, strjoin(resolution_choices, "', '"));
+    end
+
+    n = find(strcmpi('outfile', varargin));
+    if ~isempty(n)
+        outfile = varargin{n+1};
+    end
+end
+
+if strcmp(org, 'osu')
+    use_res_in_outname = false;
+else
+    use_res_in_outname = true;
+end
+if strcmp(resolution, '2m')
+    use_res_in_outname = true;
+end
+
+fileNames = selectTilesForMerging(tileDir,varargin{:});
 
 % find neighbors
 [ntop,nright,ntopRight,nbottomRight] = findNeighborTiles(fileNames);
@@ -24,7 +57,9 @@ nN(ntopRight(:,1),6) = ntopRight(:,2); %top-right
 nN(ntopRight(:,2),7) = ntopRight(:,1); %bottom-left
 nN(nbottomRight(:,1),8) = nbottomRight(:,2); %bottom-right
 
-if use_res_in_outname
+if ~isempty(outfile)
+    tileNeighborIndexFile=outfile;
+elseif use_res_in_outname
     tileNeighborIndexFile=[tileDir,'/tileNeighborIndex_',resolution,'.mat'];
 else
     tileNeighborIndexFile=[tileDir,'/tileNeighborIndex.mat'];

--- a/undoMergeTileBuffersSingle.m
+++ b/undoMergeTileBuffersSingle.m
@@ -30,7 +30,7 @@ edge_n = [];
 
 edgeName_choices = {'all', 'top', 'bottom', 'left', 'right'};
 if ~ismember(edgeName, edgeName_choices)
-    error("'edgeName' must be one of the following: {'%s'}", strjoin(edgeName_choices, "', '"));
+    error("'edgeName' must be one of the following, but was '%s': {'%s'}", edgeName, strjoin(edgeName_choices, "', '"));
 end
 if strcmp(edgeName, 'all')
     edge_n = [];
@@ -55,7 +55,7 @@ else
     whichArrays = 'all';
 end
 if ~ismember(whichArrays, whichArrays_choices)
-    error("'whichArrays' must be one of the following: {'%s'}", strjoin(whichArrays_choices, "', '"));
+    error("'whichArrays' must be one of the following, but was '%s': {'%s'}", whichArrays, strjoin(whichArrays_choices, "', '"));
 end
 
 n = find(strcmpi('ignoreMergedVars', varargin));

--- a/undoMergeTileBuffersSingle.m
+++ b/undoMergeTileBuffersSingle.m
@@ -170,8 +170,21 @@ elseif strcmp(whichArrays, 'all-but-z')
 end
 
 for array_idx = 1:length(reset_array_names)
-    data_array_name = reset_array_names{array_idx};     % ex. 'z'
-    buff_array_name = [data_array_name,'buff'];         % ex. 'zbuff'
+    data_array_name = reset_array_names{array_idx};         % ex. 'z'
+    buff_array_name = [data_array_name,'buff'];             % ex. 'zbuff'
+    corners_array_name = [data_array_name,'buffcorners'];   % ex. 'zbuffcorners'
+    % TODO: If -buffcorners array exists, it contains the *original*
+    % corner values for the buffer zones. We should use this to ensure
+    % the data arrays are reset to the true original values in the corners,
+    % instead of assuming that the left and right buffers contain the original
+    % values in the the corners.
+    % If you're not aware, doing a 'row' merge followed by a 'column' merge results
+    % in the top and bottom buffers containing row-merged values at the ends of their
+    % buffer arrays (at the corners of the tile). This is kinda both a feature and an issue,
+    % because it results in a continuous feather merge, but can be the source of artificial
+    % seamlines when the order of row/column merging is not consistent across the mosaic.
+    % With the new "preciseCorners" option to mergeTileBuffer.m (should be enabled by default),
+    % we attempt to properly handle this corner issue.
     if ~ismember(buff_array_name, m_varlist)
         continue;
     end

--- a/undoMergeTileBuffersSingle.m
+++ b/undoMergeTileBuffersSingle.m
@@ -91,6 +91,9 @@ data_array_names = {
     'tmin',
     'tmax',
 };
+exclude_array_names = {
+    'land',
+};
 if ~all(ismember(data_array_names, m_varlist))
     data_array_names
     error("One or more expected data arrays do not exist in tile struct")
@@ -99,7 +102,7 @@ end
 % Add data arrays that might be missing from the above list
 z_size = size(m_struct, 'z');
 data_array_names_same_sz = m_varlist(cellfun(@(name) isequal(size(m_struct, name), z_size), m_varlist));
-data_array_names = union(data_array_names, data_array_names_same_sz);
+data_array_names = setdiff(union(data_array_names, data_array_names_same_sz), exclude_array_names);
 
 buff_array_names = cellfun(@(name) [name,'buff'], data_array_names, 'UniformOutput',false);
 

--- a/writeGeotiff.m
+++ b/writeGeotiff.m
@@ -31,7 +31,7 @@ else
 end
 out_format_choices = {'GTiff', 'COG'};
 if ~any(strcmp(out_format, out_format_choices))
-    error("'out_format' must be one of the following: {'%s'}", strjoin(out_format_choices, "', '"))
+    error("'out_format' must be one of the following, but was '%s': {'%s'}", out_format, strjoin(out_format_choices, "', '"))
 end
 
 n = find(strcmpi('co_predictor',varargin));
@@ -55,7 +55,7 @@ elseif strcmp(out_format, 'COG')
     co_predictor_choices = {'NO', 'STANDARD', 'FLOATING_POINT', 'YES'};
 end
 if ~any(strcmp(out_format, out_format_choices))
-    error("'co_predictor' must be one of the following: {'%s'}", strjoin(co_predictor_choices, "', '"))
+    error("'co_predictor' must be one of the following, but was '%s': {'%s'}", out_format, strjoin(co_predictor_choices, "', '"))
 end
 
 if strcmp(out_format, 'COG')

--- a/writeTileToTifv4.m
+++ b/writeTileToTifv4.m
@@ -2,6 +2,13 @@ function writeTileToTifv4(tilef,projstr,varargin)
 % Write 2m or 10m dem matfiles to tif
 %   compatible with setsm_postprocesing v4 branch
 
+n = find(strcmpi('overwrite',varargin));
+if ~isempty(n)
+    overwrite = true;
+else
+    overwrite = false;
+end
+
 n = find(strcmpi('outRasterType',varargin));
 if ~isempty(n)
     outRasterType = varargin{n+1};
@@ -119,7 +126,7 @@ outNameBase = strrep(tilef,'_reg.mat','.mat');
 
 fprintf('Writing DEM\n')
 outNameDem = strrep(outNameBase,'.mat','_dem.tif');
-if exist(outNameDem,'file')
+if exist(outNameDem,'file') && ~overwrite
     browse_keep_dem = true;
     fprintf('%s exists, skipping\n',outNameDem);
 else
@@ -143,7 +150,7 @@ if ~browse_only
     if contains('z_mad',flds)
         fprintf('Writing mad\n')
         outNameTif = strrep(outNameBase,'.mat','_mad.tif');
-        if exist(outNameTif,'file')
+        if exist(outNameTif,'file') && ~overwrite
             fprintf('%s exists, skipping\n',outNameTif);
         else
             z_mad=m.z_mad(ny(1):ny(end),nx(1):nx(end));
@@ -164,7 +171,7 @@ if ~browse_only
     if contains('N',flds)
         fprintf('Writing N\n')
         outNameTif = strrep(outNameBase,'.mat','_count.tif');
-        if exist(outNameTif,'file')
+        if exist(outNameTif,'file') && ~overwrite
             fprintf('%s exists, skipping\n',outNameTif);
         else
             N=m.N(ny(1):ny(end),nx(1):nx(end));
@@ -184,7 +191,7 @@ if ~browse_only
     if contains('Nmt',flds)
         fprintf('Writing Nmt\n')
         outNameTif = strrep(outNameBase,'.mat','_countmt.tif');
-        if exist(outNameTif,'file')
+        if exist(outNameTif,'file') && ~overwrite
             fprintf('%s exists, skipping\n',outNameTif);
         else
             Nmt=m.Nmt(ny(1):ny(end),nx(1):nx(end));
@@ -204,7 +211,7 @@ if ~browse_only
     if contains('tmax',flds)
         fprintf('Writing tmax\n')
         outNameTif = strrep(outNameBase,'.mat','_maxdate.tif');
-        if exist(outNameTif,'file')
+        if exist(outNameTif,'file') && ~overwrite
             fprintf('%s exists, skipping\n',outNameTif);
         else
             tmax=m.tmax(ny(1):ny(end),nx(1):nx(end));
@@ -224,7 +231,7 @@ if ~browse_only
     if contains('tmin',flds)
         fprintf('Writing tmin\n')
         outNameTif = strrep(outNameBase,'.mat','_mindate.tif');
-        if exist(outNameTif,'file')
+        if exist(outNameTif,'file') && ~overwrite
             fprintf('%s exists, skipping\n',outNameTif);
         else
             tmin=m.tmin(ny(1):ny(end),nx(1):nx(end));
@@ -247,7 +254,7 @@ fprintf('Writing browse\n')
 
 % if 2m posting, first downsample to 10m
 outNameBrowse = strrep(outNameBase,'.mat','_browse.tif');
-if exist(outNameBrowse,'file')
+if exist(outNameBrowse,'file') && ~overwrite
     fprintf('%s exists, skipping\n',outNameBrowse);
 else
     [epsg,~,~] = getProjstrInfo(projstr);

--- a/writeTileToTifv4.m
+++ b/writeTileToTifv4.m
@@ -10,7 +10,7 @@ else
 end
 outRasterType_choices = {'browse-LZW', 'browse-COG', 'full-LZW', 'full-COG'};
 if ~any(strcmp(outRasterType, outRasterType_choices))
-    error("'outRasterType' must be one of the following: {'%s'}", strjoin(outRasterType_choices, "', '"))
+    error("'outRasterType' must be one of the following, but was '%s': {'%s'}", outRasterType, strjoin(outRasterType_choices, "', '"))
 end
 
 if ismember(outRasterType, {'browse-LZW', 'browse-COG'})

--- a/writeTileToTifv4.m
+++ b/writeTileToTifv4.m
@@ -36,8 +36,8 @@ end
 
 fprintf('Source: %s\n',tilef);
 
-% output tile buffer in pixels
-buffer = 10;
+% output tile buffer in meters
+buffer_meters = 100;
 
 % load m file and get coordinate vectors
 m=matfile(tilef);
@@ -109,11 +109,12 @@ nx(end) = nx(end)-1;
 ny(end) = ny(end)-1;
 
 % add standard tile buffer
-if buffer > 0
-    nx(1) = max(nx(1)-buffer, 1);
-    nx(2) = min(nx(2)+buffer, length(x));
-    ny(1) = max(ny(1)-buffer, 1);
-    ny(2) = min(ny(2)+buffer, length(y));
+if buffer_meters > 0
+    buffer_px = buffer_meters / dx;
+    nx(1) = max(nx(1)-buffer_px, 1);
+    nx(2) = min(nx(2)+buffer_px, length(x));
+    ny(1) = max(ny(1)-buffer_px, 1);
+    ny(2) = min(ny(2)+buffer_px, length(y));
 end
 
 %crop coordinate vectors


### PR DESCRIPTION
Changes to most of the post-process steps were relatively simple added `varargin` option functionality for breaking up work on the mosaic tiles to a subset of tiles, to enable parallel tile processing on PGC's compute cluster.

Significant changes were made to `mergeTileBuffer.m`, building on the [recently-added `adjustFeatherZone` functionality](https://github.com/ihowat/setsm_postprocessing/commit/a151af58608894f3f43d1868af50229eed71ab27) through the following major commits:
- [Only fill NoData holes in tile overlap area outside of feathering zone](https://github.com/ihowat/setsm_postprocessing/commit/f647ad98f6347092c20e3b61f3b57ae53b4a2e02)
- [Add more smarts to adjustFeatherZone to work on tile buffers over water](https://github.com/ihowat/setsm_postprocessing/commit/1f348a9e3687aa2693d2552900febeb49c800e21) 

- [mergeTileBuffer.m new 'preciseCorners' varargin](https://github.com/ihowat/setsm_postprocessing/commit/6faac8fae783ddb4047d1d5899aa6b8d0420a7d2)