### PR TITLE
dzfit application adjustments for finishing REMA v2 2m mosaic tiles

### DIFF
--- a/applyDzfitTo2m.m
+++ b/applyDzfitTo2m.m
@@ -22,14 +22,15 @@ for i=1:length(fileNames)
     fileName10m=fileNames{i};
     
     [tiledir,filename10m_base,filename10m_ext]= fileparts(fileName10m);
+    fileName10mName = [filename10m_base,filename10m_ext];
 
     if isempty(dir2m_arg)
         dir2m = tiledir;
     end
-    fileNames2m = {[dir2m,'/',strrep(filename10m_base,'10m_reg','1_1_2m_reg.mat')],...
-                   [dir2m,'/',strrep(filename10m_base,'10m_reg','1_2_2m_reg.mat')],...
-                   [dir2m,'/',strrep(filename10m_base,'10m_reg','2_1_2m_reg.mat')],...
-                   [dir2m,'/',strrep(filename10m_base,'10m_reg','2_2_2m_reg.mat')]};
+    fileNames2m = {[dir2m,'/',strrep(fileName10mName,'10m_reg.mat','1_1_2m_reg.mat')],...
+                   [dir2m,'/',strrep(fileName10mName,'10m_reg.mat','1_2_2m_reg.mat')],...
+                   [dir2m,'/',strrep(fileName10mName,'10m_reg.mat','2_1_2m_reg.mat')],...
+                   [dir2m,'/',strrep(fileName10mName,'10m_reg.mat','2_2_2m_reg.mat')]};
     
     n = cellfun( @exist, fileNames2m);
     
@@ -49,10 +50,10 @@ for i=1:length(fileNames)
     % resize dzfit to 10m z
     dzfit0 = imresize(m10.dzfit,sz);
     
-    % resize dz0 to 10m z
-    dz0 = imresize(m10.dz0,sz);
+%    % resize dz0 to 10m z
+%    dz0 = imresize(m10.dz0,sz);
     
-    
+
     j=1;
     for j=1:length(fileNames2m)
 
@@ -60,16 +61,19 @@ for i=1:length(fileNames)
         
         % interpolate 10m full tile to 2m quad grid
         dzfit = interp2(m10.x,m10.y,dzfit0,m2.x,m2.y,'*bilinear');
-        dz0 = interp2(m10.x,m10.y,dzfit0,m2.x,m2.y,'*bilinear');
+%        dz0 = interp2(m10.x,m10.y,dzfit0,m2.x,m2.y,'*bilinear');
         
         % apply to z
         m2.Properties.Writable = true;
         m2.z = m2.z - dzfit;
-        m2.z = m2.z - dz0;
-        
+%        m2.z = m2.z - dz0;
+
+        m2.dzfitApplied = true;
+%        m2.adjusted = true;
+
         % downsample dzfit and add to mat file
         m2.dzfit = imresize(dzfit,0.01);
-        m2.dz0 = imresize(dz0,0.01);
+%        m2.dz0 = imresize(dz0,0.01);
     end
     
 end

--- a/applyRegTo2m.m
+++ b/applyRegTo2m.m
@@ -1,0 +1,100 @@
+function applyRegTo2m(fileNames,dir2m)
+% applyDzfitTo2m apply the dzfit field from 10m to its 2m quad tiles
+%
+% applyDzfitTo2m(fileNames,dir2m) with the 10m files containing the dzfit
+% field and the path in dir2m containing the corresponding 2m quad tiles.
+% Insert '.' if in same path. The 10m files must have a name format 
+% *10m_reg.mat with the corresponding 2m having a format *2m_r_c_reg.mat
+
+
+if ~iscell(fileNames)
+    fileNames={fileNames};
+end
+
+dir2m_arg = dir2m;
+
+
+% loop through files (can be done in parallel)
+i=1;
+for i=1:length(fileNames)
+    
+    % get 10m file name
+    fileName10m=fileNames{i};
+
+    fprintf('Working on 10m tile: %s\n', fileName10m)
+    
+    [tiledir,filename10m_base,filename10m_ext]= fileparts(fileName10m);
+    fileName10mName = [filename10m_base,filename10m_ext];
+
+    if isempty(dir2m_arg)
+        dir2m = tiledir;
+    end
+    fileNames2m = {[dir2m,'/',strrep(fileName10mName,'10m_reg.mat','1_1_2m.mat')],...
+                   [dir2m,'/',strrep(fileName10mName,'10m_reg.mat','1_2_2m.mat')],...
+                   [dir2m,'/',strrep(fileName10mName,'10m_reg.mat','2_1_2m.mat')],...
+                   [dir2m,'/',strrep(fileName10mName,'10m_reg.mat','2_2_2m.mat')]};
+    
+    n = cellfun( @exist, fileNames2m);
+    
+    if ~any(n)
+        warning('ERROR: no 2m files found for %s',fileName10m)
+        continue
+    end
+    
+    fileNames2m(~n) = [];
+
+    m10 = matfile(fileName10m);
+
+    % get the size of 10m z
+    s=whos(m10);
+    sz = s(strcmp({s.name},'z')).size;
+
+    if any(strcmp(fields(m10),'dzfit')) && ~isempty(m10.dzfit)
+        % resize dzfit to 10m z
+        dzfit0 = imresize(m10.dzfit,sz);
+    else
+        dzfit0 = [];
+    end
+    
+    
+    j=1;
+    for j=1:length(fileNames2m)
+
+        fileName2m_unreg = fileNames2m{j};
+        fileName2m_reg = strrep(fileName2m_unreg,'.mat','_reg.mat');
+
+        fprintf('Working on 2m tile: %s\n', fileName2m_unreg)
+
+        applyRegistration(fileName2m_unreg,[],'demMatFileWithRegToCopy',fileName10m);
+        if ~exist(fileName2m_reg)
+            error('failed to create 2m reg tile file for %s',fileName2m_unreg)
+        end
+
+        fprintf('2m reg file was created: %s\n', fileName2m_reg)
+
+        if ~isempty(dzfit0)
+            fprintf('Applying dzfit from 10m to 2m tile\n')
+
+            m2 = matfile(fileName2m_reg);
+
+            % interpolate 10m full tile to 2m quad grid
+            dzfit = interp2(m10.x,m10.y,dzfit0,m2.x,m2.y,'*bilinear');
+
+            % apply to z
+            m2.Properties.Writable = true;
+            m2.z = m2.z - dzfit;
+            m2.dzfitApplied = true;
+
+            % downsample dzfit and add to mat file
+            m2.dzfit = imresize(dzfit,0.01);
+        end
+    end
+    
+end
+    
+   
+    
+    
+        
+    
+    

--- a/batchRegisterTiles.m
+++ b/batchRegisterTiles.m
@@ -10,6 +10,8 @@ function batchRegisterTiles(tileDir,is2Dir,varargin)
 strt=1;
 inc=1;
 resolution='10m';
+overwrite=false;
+overwrite_flag='';
 
 if length(varargin) == 2 && ~isnan(str2double(varargin{1})) && ~isnan(str2double(varargin{2}))
     strt=varargin{1};
@@ -33,6 +35,11 @@ elseif ~isempty(varargin)
     end
     if ~ismember(resolution, resolution_choices)
         error("'resolution' must be one of the following, but was '%s': {'%s'}", resolution, strjoin(resolution_choices, "', '"));
+    end
+
+    if any(strcmpi(varargin,'overwrite'))
+        overwrite=true;
+        overwrite_flag='overwrite';
     end
 end
 
@@ -60,12 +67,18 @@ for i=strt:inc:length(tileFiles)
     
     fprintf('%d of %d, %s\n',i,length(tileNames10m),tileFile)
 
-    registerTileToIS2(tileFile,is2TileFile)
-     
-    applyRegistration(tileFile,[])
-    
     regTileFile=strrep(tileFile,'.mat','_reg.mat');
-    
+    unregTileFile=strrep(tileFile,'.mat','_unreg.mat.bak');
+
+    if ~exist(unregTileFile,'file')
+        eval(['!cp ',tileFile,' ',unregTileFile]);
+    end
+
+    if ~exist(regTileFile,'file') || overwrite
+        registerTileToIS2(tileFile,is2TileFile)
+        applyRegistration(tileFile,[],overwrite_flag)
+    end
+
     if exist(regTileFile,'file')
         fit2is2(regTileFile,is2TileFile)
     end

--- a/batchRegisterTiles.m
+++ b/batchRegisterTiles.m
@@ -12,6 +12,8 @@ inc=1;
 resolution='10m';
 overwrite=false;
 overwrite_flag='';
+skipDzfit=false;
+dzfitMinPoints=[];
 
 if length(varargin) == 2 && ~isnan(str2double(varargin{1})) && ~isnan(str2double(varargin{2}))
     strt=varargin{1};
@@ -40,6 +42,15 @@ elseif ~isempty(varargin)
     if any(strcmpi(varargin,'overwrite'))
         overwrite=true;
         overwrite_flag='overwrite';
+    end
+
+    if any(strcmpi(varargin,'skipDzfit'))
+        skipDzfit=true;
+    end
+
+    n = find(strcmpi('dzfitMinPoints', varargin));
+    if ~isempty(n)
+        dzfitMinPoints = varargin{n+1};
     end
 end
 
@@ -79,7 +90,7 @@ for i=strt:inc:length(tileFiles)
         applyRegistration(tileFile,[],overwrite_flag)
     end
 
-    if exist(regTileFile,'file')
-        fit2is2(regTileFile,is2TileFile)
+    if exist(regTileFile,'file') && ~skipDzfit
+        fit2is2(regTileFile,is2TileFile,'dzfitMinPoints',dzfitMinPoints)
     end
 end

--- a/batchRegisterTiles.m
+++ b/batchRegisterTiles.m
@@ -90,7 +90,14 @@ for i=strt:inc:length(tileFiles)
         applyRegistration(tileFile,[],overwrite_flag)
     end
 
-    if exist(regTileFile,'file') && ~skipDzfit
-        fit2is2(regTileFile,is2TileFile,'dzfitMinPoints',dzfitMinPoints)
+    if ~exist(regTileFile,'file')
+        fprintf('registered tile was not created, skipping dzfit\n')
+    else
+        if skipDzfit
+            fprintf('skipping dzfit due to provided skipDzfit flag\n')
+        else
+            fprintf('calculating dzfit\n')
+            fit2is2(regTileFile,is2TileFile,'dzfitMinPoints',dzfitMinPoints)
+        end
     end
 end

--- a/batch_applyRegTo2m.m
+++ b/batch_applyRegTo2m.m
@@ -1,0 +1,58 @@
+function batch_applyRegTo2m(remaTileDir,varargin)
+%batch_applyRegistration initializes the calls to applyRegistration, which
+%shifts and interpolates the tile mosaics (all rasters) within mat files.
+% Currently set to operate on tiles within a region directory.
+% Makes a new .mat file called *_reg.mat
+%
+% Compatible with v4 mosaics.
+%
+% Should be resolution agnostic.
+
+%% Paths/files
+% upper level directory where region directories sit
+%remaTileDir='~/Desktop';
+%remaTileDir='/fs/project/howat.4/howat.4/automosaic13e';
+%remaTileDir='~/project/howat.4/rema_mosaic_v13e';
+
+%remaTileDir='/fs/project/howat.4/howat.4/rema_mosaic/rema_mosaic_v13e';
+
+% region name (which is the name of the region directory). If empty, does
+% not use region directory (i.e. if all files are in one folder)
+% regionName='rema_21_mbl_north';
+%regionName='';
+
+% File with list of registration parameters, indexed by tile name
+% if empty, uses reg variable in tile mat
+%registrationFile=  /fs/byo/howat-data4/REMA/altimetryByTile/rema_{region number}_{region name}_is2reg.mat
+%registrationFile= '~/data4/REMA/altimetryByTile/rema_21_mbl_north_is2reg.mat';
+%registrationFile=[];
+
+strt=1;
+inc=1;
+if length(varargin) == 2
+    strt=varargin{1};
+    inc= varargin{2};
+end
+fprintf('processing every %d tile, starting at %d\n',inc,strt)
+
+
+%% Read file list
+demMatFiles=dir([remaTileDir,'/','*_10m_reg.mat']);
+demMatFiles=cellfun( @(x) [remaTileDir,'/',x],...
+    {demMatFiles.name}, 'uniformoutput',0);
+
+fprintf('%d tiles found\n',length(demMatFiles))
+
+%% loop through tiles
+for i=strt:inc:length(demMatFiles)
+    
+    % 10m tile file to apply registration to 2m quad tiles
+    demMatFile=demMatFiles{i};
+    
+    applyRegTo2m(demMatFile,[])
+    
+end
+
+
+
+

--- a/boundaryAdjustCalc.m
+++ b/boundaryAdjustCalc.m
@@ -9,10 +9,11 @@ function boundaryAdjustCalc(fileName,neighborFiles,varargin)
 
 m0=matfile(fileName);
 
-% standard resizeFraction is for 10m, scale for 2m and other res
-resizeFraction_10m = 0.1;
-res = m0.x(1,2) - m0.x(1,1);
-resizeFraction = min(1.0, resizeFraction_10m * (res/10));
+resizeFraction = 0.1;
+%% standard resizeFraction is for 10m, scale for 2m and other res
+%resizeFraction_10m = 0.1;
+%res = m0.x(1,2) - m0.x(1,1);
+%resizeFraction = min(1.0, resizeFraction_10m * (res/10));
 
 n=find(strcmpi(varargin,'resizeFraction'));
 if ~isempty(n)

--- a/fit2is2.m
+++ b/fit2is2.m
@@ -12,6 +12,12 @@ s=whos(m);
 % get the size of z
 sz = s(strcmp({s.name},'z')).size;
 
+dzfitMinPoints = [];
+n = find(strcmpi('dzfitMinPoints', varargin));
+if ~isempty(n)
+    dzfitMinPoints = varargin{n+1};
+end
+
 if any(strcmp(fields(m),'dzfitApplied'))
     if m.dzfitApplied==1
         if ~any(strcmp(varargin,'overwrite'))
@@ -44,9 +50,9 @@ is2 = structfun( @(x) x(n), is2, 'uniformoutput', 0);
 
 % call the surfacef fitter with or without land mask if it exists
 if any(strcmp({s.name},'land'))
-    [dzfit,sf]=fitDEM2gcps(x,y,z,is2.x,is2.y,is2.z,'resizeFactor',0.01,'landMask',land);
+    [dzfit,sf]=fitDEM2gcps(x,y,z,is2.x,is2.y,is2.z,'resizeFactor',0.01,'landMask',land,'minPoints',dzfitMinPoints);
 else
-    [dzfit,sf]=fitDEM2gcps(x,y,z,is2.x,is2.y,is2.z,'resizeFactor',0.01);
+    [dzfit,sf]=fitDEM2gcps(x,y,z,is2.x,is2.y,is2.z,'resizeFactor',0.01,'minPoints',dzfitMinPoints);
 end
 
 if isempty(dzfit)

--- a/fit2is2.m
+++ b/fit2is2.m
@@ -30,11 +30,23 @@ end
 %load is2 data
 is2 =load(is2FileName,'x','y','z');
 
+try
+    %load DEM
+    load(tileFileName,'x','y','z','land');
+catch
+    warning('cant read %s\n',tileFileName)
+    return
+end
+
+% remove is2 points that fall outside of the (2m) tile
+n = is2.x >= min(x) & is2.x <= max(x) & is2.y >= min(y) & is2.y <= max(y);
+is2 = structfun( @(x) x(n), is2, 'uniformoutput', 0);
+
 % call the surfacef fitter with or without land mask if it exists
 if any(strcmp({s.name},'land'))
-    [dzfit,sf]=fitDEM2gcps(m.x,m.y,m.z,is2.x,is2.y,is2.z,'resizeFactor',0.01,'landMask',m.land);
+    [dzfit,sf]=fitDEM2gcps(x,y,z,is2.x,is2.y,is2.z,'resizeFactor',0.01,'landMask',land);
 else
-    [dzfit,sf]=fitDEM2gcps(m.x,m.y,m.z,is2.x,is2.y,is2.z,'resizeFactor',0.01);
+    [dzfit,sf]=fitDEM2gcps(x,y,z,is2.x,is2.y,is2.z,'resizeFactor',0.01);
 end
 
 if isempty(dzfit)

--- a/fit2is2.m
+++ b/fit2is2.m
@@ -56,7 +56,10 @@ else
 end
 
 if isempty(dzfit)
+    fprintf('dzfit is empty and will not be applied\n')
     return
+else
+    fprintf('applying dzfit\n')
 end
 
 % add downscaled surface to the file

--- a/fitDEM2gcps.m
+++ b/fitDEM2gcps.m
@@ -10,9 +10,17 @@ function [dzfit,sf]=fitDEM2gcps(x,y,z,px,py,pz,varargin)
 % resized to the orginal DEM size with imresize(dzfit,size(z)). 
 
 minPoints = 1000;
+%minPoints = 10000;
+%minLand = -1;
+minLand = 0.95;
+
+%resizeFactor=0.01;
+% standard resizeFactor is for 10m, scale for 2m and other res
+resizeFactor_10m = 0.01;
+res = x(1,2) - x(1,1);
+resizeFactor = min(1.0, resizeFactor_10m * (res/10));
 
 % get varargins
-resizeFactor=0.01;
 n = find(strcmpi(varargin,'resizefactor'));
 if ~isempty(n)
     resizeFactor=varargin{n+1};
@@ -27,6 +35,13 @@ end
 zi = interp2(x,y,z,px,py,'*linear');
 
 if exist('land','var')
+    if nnz(land)/numel(land) < minLand
+        warning('not enough land in tile to create accurate surface, returning')
+        dzfit = [];
+        sf=[];
+        return
+    end
+
     if any(~land(:))
         land = interp2(x,y,land,px,py,'*nearest',0);
         zi(land ~= 1) = NaN;

--- a/fitDEM2gcps.m
+++ b/fitDEM2gcps.m
@@ -31,6 +31,22 @@ if ~isempty(n)
     land=varargin{n+1};
 end
 
+n = find(strcmpi(varargin, 'minPoints'));
+if ~isempty(n)
+    argval=varargin{n+1};
+    if ~isempty(argval)
+        minPoints=argval;
+    end
+end
+
+n = find(strcmpi(varargin, 'minLand'));
+if ~isempty(n)
+    argval=varargin{n+1};
+    if ~isempty(argval)
+        minLand=argval;
+    end
+end
+
 % interpolate dem to control point coordinates
 zi = interp2(x,y,z,px,py,'*linear');
 

--- a/fitDEM2gcps.m
+++ b/fitDEM2gcps.m
@@ -54,7 +54,7 @@ dz(n) = [];
 
 % fit a quadratic surface to point offsets
 warning off % get precision and fit warnings, just ignore them
-sf = fit([px, py],dz,'poly23');
+sf = fit([px, py],dz,'poly22');
 warning on
 
 % resize the DEM coordinates to calculate the surface

--- a/registerTileToIS2.m
+++ b/registerTileToIS2.m
@@ -15,6 +15,29 @@ resizeFraction = min(1.0, resizeFraction_10m * (res/10));
 resizeFraction = 1.0;
 
 
+% make sure data array altering post-process steps have not been applied
+m_struct = m;
+m_varlist = who(m_struct);
+
+dzfitApplied = ismember('dzfitApplied', m_varlist) && m_struct.dzfitApplied;
+adjusted = ismember('adjusted', m_varlist) && m_struct.adjusted;
+
+mergedTop = ismember('mergedTop', m_varlist) && m_struct.mergedTop;
+mergedBottom = ismember('mergedBottom', m_varlist) && m_struct.mergedBottom;
+mergedLeft = ismember('mergedLeft', m_varlist) && m_struct.mergedLeft;
+mergedRight = ismember('mergedRight', m_varlist) && m_struct.mergedRight;
+
+if dzfitApplied
+    error('unregistered tile somehow has dzfit applied, please investigate')
+end
+if adjusted
+    error('unregistered tile has adjust flag true, cannot register')
+end
+if mergedTop || mergedBottom || mergedLeft || mergedRight
+    error('unregistered tile has had at least one side merged, cannot register')
+end
+
+
 if any(strcmp(fields(m),'unreg'))
     fprintf('unreg field already exists, clearing: %s\n', tileFile)
     m.Properties.Writable = true;

--- a/registerTileToIS2.m
+++ b/registerTileToIS2.m
@@ -15,10 +15,15 @@ resizeFraction = min(1.0, resizeFraction_10m * (res/10));
 resizeFraction = 1.0;
 
 
+if any(strcmp(fields(m),'unreg'))
+    fprintf('unreg field already exists, clearing: %s\n', tileFile)
+    m.Properties.Writable = true;
+    m.unreg = [];
+end
 if any(strcmp(fields(m),'reg'))
-    fprintf('reg already exists, skipping\n')
-    clear m
-    return
+    fprintf('reg field already exists, clearing: %s\n', tileFile)
+    m.Properties.Writable = true;
+    m.reg = [];
 end
 
 % skip if is2 file doesnt exist for this tile

--- a/registerTileToIS2.m
+++ b/registerTileToIS2.m
@@ -43,6 +43,10 @@ catch
     return
 end
 
+% remove is2 points that fall outside of the (2m) tile
+n = is2.x >= min(x) & is2.x <= max(x) & is2.y >= min(y) & is2.y <= max(y);
+is2 = structfun( @(x) x(n), is2, 'uniformoutput', 0);
+
 if resizeFraction ~= 1.0
     x = imresize(x, resizeFraction);
     y = imresize(y, resizeFraction);


### PR DESCRIPTION
Three notable changes:
- [Remove is2 points that fall outside (2m) tile bounds from consideration](https://github.com/ihowat/setsm_postprocessing/commit/28307e3114e8d7f2ace0a66d7e200ac07cfdf20e)
- [Bugfix dzfit surface fit model ('poly23' -> 'poly22')](https://github.com/ihowat/setsm_postprocessing/commit/e05f93e0faecda8e932aa4aabae4697f7a92b66c)
- [Adjust dzfit application for 2m tiles (automatically skip applying dzfit for tiles over coastline)](https://github.com/ihowat/setsm_postprocessing/commit/20c452561819b5951126e8e7ad39211502a9511f)