### PR TITLE
Fix date raster bug in tiles built from strips_v4.1 data

### DIFF
--- a/buildSubTiles.m
+++ b/buildSubTiles.m
@@ -433,7 +433,7 @@ parfor n=nstrt:subN
     
     % make date vector
     [~,name] =  cellfun(@fileparts,fileNames,'uniformoutput',0);
-    t=cellfun(@(x) datenum(x(6:13),'yyyymmdd'),name)';
+    t=cellfun(@(x) datenum(parsePairnameDatestring(x),'yyyymmdd'),name)';
     
     %% extract strip subsets into stack
     fprintf('extracting %d strip subsets ',length(fileNames))

--- a/buildSubTiles.m
+++ b/buildSubTiles.m
@@ -818,7 +818,7 @@ function make2m(fileNames,x,y,dZ,dX,dY,land,fa,qc_x,qc_y,outName)
 
 % make date vector
 [~,name] =  cellfun(@fileparts,fileNames,'uniformoutput',0);
-t=cellfun(@(x) datenum(x(6:13),'yyyymmdd'),name)';
+t=cellfun(@(x) datenum(parsePairnameDatestring(x),'yyyymmdd'),name)';
 
 % layers with missing adjustments
 n_missing = isnan(dZ);

--- a/buildSubTilesSortFix.m
+++ b/buildSubTilesSortFix.m
@@ -234,7 +234,7 @@ function make2m(fileNames,x,y,dZ,dX,dY,land,fa,outName)
 
 % make date vector
 [~,name] =  cellfun(@fileparts,fileNames,'uniformoutput',0);
-t=cellfun(@(x) datenum(x(6:13),'yyyymmdd'),name)';
+t=cellfun(@(x) datenum(parsePairnameDatestring(x),'yyyymmdd'),name)';
 
 % layers with missing adjustments
 n_missing = isnan(dZ);

--- a/compileStripMeta.m
+++ b/compileStripMeta.m
@@ -16,8 +16,7 @@ med_rmse=nan(size(f));
 max_rmse=nan(size(f));
 Nscenes=nan(size(f));
 
-stripDate=char(f{:});
-stripDate=datenum(stripDate(:,6:13),'yyyymmdd');
+stripDate=arrayfun(@(x) datenum(parsePairnameDatestring(convertCharsToStrings(x)),'yyyymmdd'), f, 'uniformoutput',0);
 
  reg.datasets       = cell(size(f));
  reg.Ngcps          = nan(size(f));

--- a/fillVoids.m
+++ b/fillVoids.m
@@ -219,7 +219,7 @@ for i=1:length(voidPolys)
 
     % make date vector
     [~,name] =  cellfun(@fileparts,fileNames,'uniformoutput',0);
-    t=cellfun(@(x) datenum(x(6:13),'yyyymmdd'),name)';
+    t=cellfun(@(x) datenum(parsePairnameDatestring(x),'yyyymmdd'),name)';
 
     % re-specify rectangular sampling area
     buffer = 100;

--- a/parsePairname.m
+++ b/parsePairname.m
@@ -1,0 +1,30 @@
+function [pairname, sensor, datestring_yyyymmdd, catalogid1, catalogid2, prefix, suffix] = parsePairname(string)
+
+prefix = [];
+pairname = [];
+sensor = [];
+datestring_yyyymmdd = [];
+catalogid1 = [];
+catalogid2 = [];
+suffix = [];
+
+pairname_re = '^(?<prefix>.*)?(?<sensor>[A-Z][A-Z0-9]{2}[0-9])_(?<date>[0-9]{8})_(?<catid1>[0-9A-F]{16})_(?<catid2>[0-9A-F]{16})(?<suffix>.*)?$';
+
+[tokens, match_idx] = regexp(string, pairname_re, 'names');
+if isempty(match_idx)
+    error("Cannot parse pairname parts with regex '%s' from input tilename string: %s", pairname_re, string);
+end
+
+if isfield(tokens, 'prefix')
+    prefix = tokens.prefix;
+end
+sensor = tokens.sensor;
+datestring_yyyymmdd = tokens.date;
+catalogid1 = tokens.catid1;
+catalogid2 = tokens.catid2;
+if isfield(tokens, 'suffix')
+    suffix = tokens.suffix;
+end
+
+pairname_parts = [sensor, datestring_yyyymmdd, catalogid1, catalogid2]
+pairname = strjoin(pairname_parts, '_');

--- a/parsePairnameDatestring.m
+++ b/parsePairnameDatestring.m
@@ -1,0 +1,30 @@
+function [datestring_yyyymmdd] = parsePairnameDatestring(string)
+
+prefix = [];
+pairname = [];
+sensor = [];
+datestring_yyyymmdd = [];
+catalogid1 = [];
+catalogid2 = [];
+suffix = [];
+
+pairname_re = '^(?<prefix>.*)?(?<sensor>[A-Z][A-Z0-9]{2}[0-9])_(?<date>[0-9]{8})_(?<catid1>[0-9A-F]{16})_(?<catid2>[0-9A-F]{16})(?<suffix>.*)?$';
+
+[tokens, match_idx] = regexp(string, pairname_re, 'names');
+if isempty(match_idx)
+    error("Cannot parse pairname parts with regex '%s' from input tilename string: %s", pairname_re, string);
+end
+
+%if isfield(tokens, 'prefix')
+%    prefix = tokens.prefix;
+%end
+%sensor = tokens.sensor;
+datestring_yyyymmdd = tokens.date;
+%catalogid1 = tokens.catid1;
+%catalogid2 = tokens.catid2;
+%if isfield(tokens, 'suffix')
+%    suffix = tokens.suffix;
+%end
+%
+%pairname_parts = [sensor, datestring_yyyymmdd, catalogid1, catalogid2]
+%pairname = strjoin(pairname_parts, '_');

--- a/update10mSubTileOutput.m
+++ b/update10mSubTileOutput.m
@@ -95,7 +95,7 @@ for n=1:length(subTileFiles)
     
     % make date vector
     [~,name] =  cellfun(@fileparts,fileNames,'uniformoutput',0);
-    t=cellfun(@(x) datenum(x(6:13),'yyyymmdd'),name)';
+    t=cellfun(@(x) datenum(parsePairnameDatestring(x),'yyyymmdd'),name)';
     
     
     t=t-datenum('1/1/2000 00:00:00');


### PR DESCRIPTION
strips_v4.1 DEM data had a "SETSM_s2s041_" prefix added to the strip DEM filenames. This silently broke the matlab `datenum` function that was parsing acquisition date from the strip filenames.

Changed to parsing the date from strip filenames using a reliable regex method.